### PR TITLE
(Ready for Review) Fixing 500 error when email is nil at post#request_reset

### DIFF
--- a/app/controllers/v1/user_controller.rb
+++ b/app/controllers/v1/user_controller.rb
@@ -1,5 +1,6 @@
 class V1::UserController < ApplicationController
   before_action :authenticate_user!, except: [:create, :reset, :request_reset]
+  before_action :downcase_email
 
   def show
     render partial: 'v1/shared/user', locals: { user: current_user }
@@ -49,7 +50,7 @@ class V1::UserController < ApplicationController
   end
 
   def request_reset
-    user = User.find_by(email: params[:email].downcase)
+    user = User.find_by(email: params[:email])
 
     render_errors("Email doesn't exist") and return unless user
     user.update(reset_password_token: hash, 
@@ -94,6 +95,10 @@ class V1::UserController < ApplicationController
 
   def send_notification_email
     SignupNotificationWorker.perform_async(@user.id)
+  end
+
+  def downcase_email
+    params[:email].downcase! unless params[:email].nil?
   end
   
   def user_params

--- a/spec/controllers/v1/user_controller_spec.rb
+++ b/spec/controllers/v1/user_controller_spec.rb
@@ -25,6 +25,11 @@ describe V1::UserController do
       assert_response :success
     end
 
+    it 'does not break when email param is nil' do
+      expect{ post :request_reset }.not_to raise_error
+      assert_response 422
+    end
+
     it 'sets the reset_password_token' do
       allow(controller).to receive(:hash).and_return('xyz')
 


### PR DESCRIPTION
When you click on request reset password, if the field is blank the server responds with a 500 error
