### PR TITLE
(Ready for Review) Fixing district for users

### DIFF
--- a/lib/tasks/fix_districts_from_user.rake
+++ b/lib/tasks/fix_districts_from_user.rake
@@ -1,0 +1,30 @@
+namespace :oneoff do
+  task :fix_user_district, [:email] => :environment do |t,args|
+    require 'csv'
+    email = args[:email]
+
+    csv_user_list_file = "#{email}/users_districs.csv"
+
+    rows_from_csv = CSV.parse(S3Wrapper.read(filename: csv_user_list_file), headers: true)
+
+    rows_from_csv.each do |row|
+      user_district = row.to_hash
+
+      user      = User.find_by(email: user_district["Email"])
+      district  = District.find_by(lea_id: user_district["Lea [Districts]"])
+
+      if user && district
+        puts "Adding User #{user.email} To #{district.name} district"
+
+        user.districts << district unless user.district_ids.include?(district.id)
+        if user.save
+          puts "Added Successfully"
+        else
+          puts "Some error came up while trying to add #{user.email} to #{district.name}: #{user.errors.full_messages}"
+        end
+      else
+        puts "User of district not found: #{user_district["Email"]} - #{user_district["Name [Districts]"]}"
+      end
+    end
+  end
+end

--- a/lib/tasks/import_assessments.rake
+++ b/lib/tasks/import_assessments.rake
@@ -17,31 +17,4 @@ namespace :db do
     import_data.to_db!
   end
 
-  task :fix_user_district, [:email] => :environment do |t,args|
-    require 'csv'
-    email = args[:email]
-
-    csv_user_list_file = "#{email}/users_districs.csv"
-
-    rows_from_csv = CSV.parse(S3Wrapper.read(filename: csv_user_list_file), headers: true)
-
-    rows_from_csv.each do |row|
-      user_district = row.to_hash
-
-      user      = User.find_by(email: user_district["Email"])
-      district  = District.find_by(lea_id: user_district["Lea [Districts]"])
-
-      if user && district
-        puts "Adding User #{user.email} To #{district.name} district"
-
-        user.districts << district unless user.district_ids.include?(district.id)
-        if user.save
-          puts "Added Successfully"
-        else
-          puts "Some error came up while trying to add #{user.email} to #{district.name}: #{user.errors.full_messages}"
-        end
-      end
-    end
-  end
-
 end


### PR DESCRIPTION
It contains a rake task to add user from the previous migration to their respective district, taking the information from the PDRedesign admin into a csv file stores in S3.
