### PR TITLE
Closes #61:  Update invitations to only include facilitator and participant

### DIFF
--- a/app/assets/javascripts/client/directives/assessments/assessmentLinks.js
+++ b/app/assets/javascripts/client/directives/assessments/assessmentLinks.js
@@ -45,8 +45,7 @@ PDRClient.directive('assessmentLinks', [
             };
 
             $scope.districtMemberPopoverContent = "<div> <i class='fa fa-bullhorn'></i><span>Facilitator</span><p>Facilitators share responsibility with the district facilitator to contact participants and view their individual responses, facilitate the consensus meeting, and view the final consensus report.</p>" +
-                                                  "<i class='fa fa-edit'></i><span>Participant</span><p>Participants respond to the individual readiness assessment survey and take part in the consensus meeting. They can view the final consensus report.</p>" +
-                                                  "<i class='fa fa-eye'></i><span>Viewer</span><p>Viewers have read-only access to the final consensus report. They cannot view individual participant responses or data.</p> </div>";
+                                                  "<i class='fa fa-edit'></i><span>Participant</span><p>Participants respond to the individual readiness assessment survey and take part in the consensus meeting. They can view the final consensus report.</p>";
 
             $scope.networkPartnerPopoverContent = "<i class='fa fa-bullhorn'></i><span>Organizer</span><p>Organizers share responsibility with the district facilitator to contact participants and view their individual responses, facilitate the consensus meeting, and view the final consensus report.</p>" +
                                                   "<i class='fa fa-eye'></i><span>Observer</span><p>Observers have read-only access to the final consensus report. They cannot view individual participant responses or data.</p> </div>";

--- a/app/assets/javascripts/client/directives/permissionsInfo.js
+++ b/app/assets/javascripts/client/directives/permissionsInfo.js
@@ -12,7 +12,7 @@ PDRClient.directive('permissionsInfo', function() {
           html : true,
           placement: $scope.placement,
           trigger: 'hover',
-          content: "<i class='fa fa-bullhorn'></i><span>Facilitator</span><p>Facilitators share responsibility with the district facilitator to contact participants and view their individual responses, facilitate the consensus meeting, and view the final consensus report.</p><i class='fa fa-pencil-square-o'></i><span>Participant</span><p>Participants responds to the individual readiness assessment survey and take part of the consensus meeting. They can view the final consensus report</p><i class='fa fa-eye'></i><span>Viewer</span><p>Viewers have read-only access to the final consensus report. They cannot view individual participant responses or data.</p>"
+          content: "<i class='fa fa-bullhorn'></i><span>Facilitator</span><p>Facilitators share responsibility with the district facilitator to contact participants and view their individual responses, facilitate the consensus meeting, and view the final consensus report.</p><i class='fa fa-pencil-square-o'></i><span>Participant</span><p>Participants responds to the individual readiness assessment survey and take part of the consensus meeting. They can view the final consensus report</p>"
         });
       });
     }],

--- a/app/assets/javascripts/client/views/modals/invite_user.html
+++ b/app/assets/javascripts/client/views/modals/invite_user.html
@@ -34,7 +34,6 @@
                 ng-model="inviteUser.role">
           <option value="participant">Participant</option>
           <option value="facilitator">Facilitator</option>
-          <option value="viewer">Viewer</option>
         </select>
         <permissions-info data-placement="right"></permissions-info>
       </div>

--- a/app/assets/javascripts/client/views/modals/request_access.html
+++ b/app/assets/javascripts/client/views/modals/request_access.html
@@ -27,9 +27,6 @@
       <span class="btn btn-primary" ng-model="accessLevel" btn-radio="'participant'">
         <i class="fa fa-edit"></i><span>Participant</span>
       </span>
-      <span class="btn btn-primary" ng-model="accessLevel" btn-radio="'viewer'">
-        <i class="fa fa-eye"></i><span>Viewer</span>
-      </span>
     </div>
   </div>
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,6 @@
 machine:
   ruby:
     version: 2.2.3
-  environment:
-    CODECLIMATE_REPO_TOKEN: "a07166e58ace09def735a2952caf25cd4387c3c86e63e8cc93cbe8336540af65"
 
 test:
   override:

--- a/lib/assessments/permission.rb
+++ b/lib/assessments/permission.rb
@@ -46,12 +46,12 @@ module Assessments
           return false
       end
       notify_user_for_access_granted(assessment, user, level)
-      return true
+      true
     end
 
     def update_level(user, level)
       unless assessment.owner?(user)
-        unless(get_level(user).to_s == level.to_s)
+        unless get_level(user).to_s == level.to_s
           revoke_level(user)
           add_level(user, level)
         end
@@ -77,23 +77,23 @@ module Assessments
           assessment.viewers.destroy(user)
         when :network_partner
           assessment.network_partners.destroy(user)
-        assessment.reload
+          assessment.reload
       end
 
     end
 
     def self.available_permissions
-      # this would be return the available and valid permissions for Assessments
       PERMISSIONS
     end
 
     def self.request_access(request_options)
       roles = request_options[:roles].class == String ? [request_options[:roles]] : request_options[:roles]
 
-      return AccessRequest.create({
-        roles: roles, token: SecureRandom.hex[0..9],
-        user: request_options[:user], assessment_id: request_options[:assessment_id]
-      })
+      return AccessRequest.create(
+          {
+              roles: roles, token: SecureRandom.hex[0..9],
+              user: request_options[:user], assessment_id: request_options[:assessment_id]
+          })
     end
 
     private
@@ -120,9 +120,9 @@ module Assessments
 
     def grant_participant(assessment, user)
       Participant.find_or_create_by(
-        assessment_id: assessment.id,
-        user_id:       user.id,
-        invited_at: Time.now)
+          assessment_id: assessment.id,
+          user_id: user.id,
+          invited_at: Time.now)
     end
 
     def notify_user_for_access_granted(assessment, user, role)

--- a/lib/assessments/permission.rb
+++ b/lib/assessments/permission.rb
@@ -126,7 +126,7 @@ module Assessments
     end
 
     def notify_user_for_access_granted(assessment, user, role)
-      AccessGrantedNotificationWorker.perform_async(assessment.id, user.id, role) unless [:participant, "participant"].include? role
+      AccessGrantedNotificationWorker.perform_async(assessment.id, user.id, role) unless [:participant, 'participant'].include? role
     end
   end
 end

--- a/lib/assessments/permission.rb
+++ b/lib/assessments/permission.rb
@@ -1,7 +1,7 @@
 module Assessments
   class Permission
 
-    PERMISSIONS = [:facilitator, :viewer, :participant]
+    PERMISSIONS = [:facilitator, :participant]
 
     attr_reader :assessment
 
@@ -22,12 +22,16 @@ module Assessments
     end
 
     def get_level(user)
-      return case
-        when assessment.facilitator?(user); :facilitator
-        when assessment.network_partner?(user); :network_partner
-        when assessment.viewer?(user); :viewer
-        when assessment.participant?(user); :participant
-        end
+      case
+        when assessment.facilitator?(user)
+          :facilitator
+        when assessment.network_partner?(user)
+          :network_partner
+        when assessment.viewer?(user)
+          :viewer
+        when assessment.participant?(user)
+          :participant
+      end
     end
 
     def add_level(user, level)

--- a/spec/lib/assessments/permission_spec.rb
+++ b/spec/lib/assessments/permission_spec.rb
@@ -1,12 +1,21 @@
 require 'spec_helper'
 
 describe Assessments::Permission do
-  before { create_magic_assessments }
+  before {
+    create_magic_assessments
+  }
 
-  let(:subject) { Assessments::Permission }
+  let(:subject) {
+    Assessments::Permission
+  }
 
-  let(:assessment) { @assessment_with_participants }
-  let(:user) { Application.create_user }
+  let(:assessment) {
+    @assessment_with_participants
+  }
+
+  let(:user) {
+    Application.create_user
+  }
 
   it 'contains the correct available permissions' do
     expect(subject.available_permissions).to eq([:facilitator, :participant])
@@ -19,14 +28,17 @@ describe Assessments::Permission do
           roles: 'facilitator',
           assessment_id: assessment.id)
 
-      expect(
-          AccessRequest.find_by(assessment_id: assessment.id, user_id: user.id)
-      ).not_to be_nil
+      expect(AccessRequest.find_by(assessment_id: assessment.id, user_id: user.id)).not_to be_nil
     end
   end
 
   context 'when determining the possible levels for a user' do
-    before do
+
+    let(:assessment_permission) {
+      Assessments::Permission.new(assessment)
+    }
+
+    before(:each) do
       participant = Participant.new
       participant.user = user
       participant.assessment = assessment
@@ -34,13 +46,13 @@ describe Assessments::Permission do
     end
 
     it 'returns the correct permission levels for a user' do
-      @assessment_permission = Assessments::Permission.new(assessment)
-      expect(@assessment_permission.possible_roles_permissions(user)).to eq([:facilitator, :viewer])
+      assessment_permission = Assessments::Permission.new(assessment)
+      expect(assessment_permission.possible_roles_permissions(user)).to eq([:facilitator])
     end
   end
 
   context 'permission level' do
-    before do
+    before(:each) do
       @ra = Application.request_access_to_assessment(assessment: assessment, user: user, roles: ['facilitator'])
       @assessment_permission = Assessments::Permission.new(assessment)
     end
@@ -48,7 +60,7 @@ describe Assessments::Permission do
     it 'accept permission request' do
       expect(AccessGrantedNotificationWorker).to receive(:perform_async)
       @assessment_permission.accept_permission_requested(user)
-      expect(assessment.facilitator?(user)).to eq(true)
+      expect(assessment.facilitator?(user)).to be true
     end
 
     it 'accept a participant request' do
@@ -57,12 +69,12 @@ describe Assessments::Permission do
           assessment: assessment, user: new_user, roles: ['participant'])
 
       @assessment_permission.accept_permission_requested(new_user)
-      expect(assessment.participant?(new_user)).to eq(true)
+      expect(assessment.participant?(new_user)).to be true
     end
 
     it 'Add permission level to user' do
       @assessment_permission.add_level(user, 'network_partner')
-      expect(assessment.network_partner?(user)).to eq(true)
+      expect(assessment.network_partner?(user)).to be true
     end
 
     it 'should respond with the list of users requesting access' do
@@ -78,7 +90,7 @@ describe Assessments::Permission do
       assessment.facilitators << @facilitator
       @assessment_permission.update_level(@facilitator, 'viewer')
 
-      expect(assessment.facilitator?(@facilitator)).to eq(false)
+      expect(assessment.facilitator?(@facilitator)).to be false
       expect(@assessment_permission.get_level(@facilitator)).to eq(:viewer)
     end
 
@@ -95,13 +107,13 @@ describe Assessments::Permission do
 
       @assessment_permission.update_level(assessment.user, 'viewer')
 
-      expect(assessment.owner?(owner)).to eq(true)
-      expect(assessment.viewer?(owner)).to eq(false)
+      expect(assessment.owner?(owner)).to be true
+      expect(assessment.viewer?(owner)).to be false
     end
   end
 
   context 'deny permission request' do
-    before do
+    before(:each) do
       Application.request_access_to_assessment(assessment: assessment, user: user, roles: ['facilitator'])
       @assessment_permission = Assessments::Permission.new(assessment)
     end
@@ -109,9 +121,7 @@ describe Assessments::Permission do
     it 'should deny permission by deleting the request' do
       @assessment_permission.deny(user)
 
-      expect(
-          @assessment_permission.get_access_request(user)
-      ).to eq(nil)
+      expect( @assessment_permission.get_access_request(user)).to be_nil
     end
   end
 
@@ -126,7 +136,7 @@ describe Assessments::Permission do
   end
 
   context 'notification emails' do
-    before do
+    before(:each) do
       @ra = Application.request_access_to_assessment(assessment: assessment, user: user, roles: ['facilitator'])
       @assessment_permission = Assessments::Permission.new(assessment)
       expect(AccessGrantedNotificationWorker).to receive(:perform_async)

--- a/spec/lib/assessments/permission_spec.rb
+++ b/spec/lib/assessments/permission_spec.rb
@@ -1,13 +1,6 @@
 require 'spec_helper'
 
 describe Assessments::Permission do
-  before {
-    create_magic_assessments
-  }
-
-  let(:subject) {
-    Assessments::Permission
-  }
 
   let(:assessment) {
     @assessment_with_participants
@@ -17,17 +10,26 @@ describe Assessments::Permission do
     Application.create_user
   }
 
-  it 'contains the correct available permissions' do
-    expect(subject.available_permissions).to eq([:facilitator, :participant])
+  before(:each) do
+    create_magic_assessments
+  end
+
+  describe '#available_permissions' do
+    it 'contains the correct available permissions' do
+      expect(Assessments::Permission.available_permissions).to eq([:facilitator, :participant])
+    end
   end
 
   context 'when requesting access to an assessment' do
-    it 'creates the access request object using request_access method' do
+
+    before(:each) do
       Assessments::Permission.request_access(
           user: user,
           roles: 'facilitator',
           assessment_id: assessment.id)
+    end
 
+    it 'creates the access request object' do
       expect(AccessRequest.find_by(assessment_id: assessment.id, user_id: user.id)).not_to be_nil
     end
   end
@@ -39,73 +41,84 @@ describe Assessments::Permission do
     }
 
     before(:each) do
-      participant = Participant.new
-      participant.user = user
-      participant.assessment = assessment
+      participant = Participant.new(user: user, assessment: assessment)
       participant.save!
     end
 
     it 'returns the correct permission levels for a user' do
-      assessment_permission = Assessments::Permission.new(assessment)
       expect(assessment_permission.possible_roles_permissions(user)).to eq([:facilitator])
     end
   end
 
   context 'permission level' do
-    before(:each) do
-      @ra = Application.request_access_to_assessment(assessment: assessment, user: user, roles: ['facilitator'])
-      @assessment_permission = Assessments::Permission.new(assessment)
+
+    let(:assessment_permission) {
+      Assessments::Permission.new(assessment)
+    }
+
+    context 'when requesting access as a facilitator' do
+      let!(:request_access) {
+        Application.request_access_to_assessment(assessment: assessment, user: user, roles: ['facilitator'])
+      }
+
+      it 'accepts a facilitator request via asynchronous call' do
+        expect(AccessGrantedNotificationWorker).to receive(:perform_async)
+        assessment_permission.accept_permission_requested(user)
+        expect(assessment.facilitator?(user)).to be true
+      end
+
+      it "returns the user's permission level" do
+        assessment_permission.accept_permission_requested(user)
+        expect(assessment_permission.get_level(user)).to eq(:facilitator)
+      end
+
+      it 'should respond with the list of users requesting access' do
+        expect(assessment_permission.requested).to include(request_access)
+      end
     end
 
-    it 'accept permission request' do
-      expect(AccessGrantedNotificationWorker).to receive(:perform_async)
-      @assessment_permission.accept_permission_requested(user)
-      expect(assessment.facilitator?(user)).to be true
-    end
+    context 'when requesting access as a participant' do
+      let(:new_user) {
+        Application.create_user
+      }
 
-    it 'accept a participant request' do
-      new_user = Application.create_user
-      Application.request_access_to_assessment(
-          assessment: assessment, user: new_user, roles: ['participant'])
+      before(:each) do
+        Application.request_access_to_assessment(
+            assessment: assessment, user: new_user, roles: ['participant'])
+      end
 
-      @assessment_permission.accept_permission_requested(new_user)
-      expect(assessment.participant?(new_user)).to be true
+      it 'accepts a participant request' do
+        assessment_permission.accept_permission_requested(new_user)
+        expect(assessment.participant?(new_user)).to be true
+      end
     end
 
     it 'Add permission level to user' do
-      @assessment_permission.add_level(user, 'network_partner')
+      assessment_permission.add_level(user, 'network_partner')
       expect(assessment.network_partner?(user)).to be true
     end
 
-    it 'should respond with the list of users requesting access' do
-      expect(@assessment_permission.requested).to include(@ra)
-    end
 
-    it 'should return the permission level of a user: #get_level method' do
-      @assessment_permission.accept_permission_requested(user)
-      expect(@assessment_permission.get_level(user)).to eq(:facilitator)
-    end
-
-    it 'should update the permission level' do
+    it 'updates the permission level' do
       assessment.facilitators << @facilitator
-      @assessment_permission.update_level(@facilitator, 'viewer')
+      assessment_permission.update_level(@facilitator, 'viewer')
 
       expect(assessment.facilitator?(@facilitator)).to be false
-      expect(@assessment_permission.get_level(@facilitator)).to eq(:viewer)
+      expect(assessment_permission.get_level(@facilitator)).to eq(:viewer)
     end
 
-    it 'should update only when the new level is different' do
+    it 'updates only when the new level is different' do
       assessment.facilitators << @facilitator
       expect(AccessGrantedNotificationWorker).not_to receive(:perform_async)
 
-      @assessment_permission.update_level(@facilitator, 'facilitator')
+      assessment_permission.update_level(@facilitator, 'facilitator')
       expect(assessment.facilitator?(@facilitator)).to eq(true)
     end
 
-    it 'owner shold not be updated' do
+    it 'does not update the owner' do
       owner = assessment.user
 
-      @assessment_permission.update_level(assessment.user, 'viewer')
+      assessment_permission.update_level(assessment.user, 'viewer')
 
       expect(assessment.owner?(owner)).to be true
       expect(assessment.viewer?(owner)).to be false
@@ -118,15 +131,15 @@ describe Assessments::Permission do
       @assessment_permission = Assessments::Permission.new(assessment)
     end
 
-    it 'should deny permission by deleting the request' do
+    it 'denies permission by deleting the request' do
       @assessment_permission.deny(user)
 
-      expect( @assessment_permission.get_access_request(user)).to be_nil
+      expect(@assessment_permission.get_access_request(user)).to be_nil
     end
   end
 
   context 'participants' do
-    it 'do not send notification for permission granted when is participant' do
+    it 'does not send notification for permission granted when is participant' do
       Application.request_access_to_assessment(assessment: assessment, user: user, roles: ['participant'])
       expect(AccessGrantedNotificationWorker).not_to receive(:perform_async)
 
@@ -142,11 +155,11 @@ describe Assessments::Permission do
       expect(AccessGrantedNotificationWorker).to receive(:perform_async)
     end
 
-    it 'Notify the user by email' do
+    it 'notifies the user by email' do
       @assessment_permission.accept_permission_requested(user)
     end
 
-    it 'Send an email when the permission level is added' do
+    it 'sends an email when the permission level is added' do
       @assessment_permission.add_level(user, 'facilitator')
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,11 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV["RAILS_ENV"] ||= 'test'
-require File.expand_path("../../config/environment", __FILE__)
-require 'support/code_coverage'
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'shoulda/matchers'
 
 
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
 RSpec.configure do |config|
@@ -19,7 +18,7 @@ RSpec.configure do |config|
   config.include Requests::JsonHelpers, type: :controller
   config.include Devise::TestHelpers,   type: :controller
 
-  config.order = "random"
+  config.order = 'random'
 end
 
 RSpec::Matchers.define :include_only_one_of do |expected|

--- a/spec/support/code_coverage.rb
+++ b/spec/support/code_coverage.rb
@@ -1,3 +1,0 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
-


### PR DESCRIPTION
This PR is good to go.  Notes:

 - Most of the work to do this effort was already covered in #72, which is why this branch is based off of that.  This PR will need to go after it.
 - The only major change required in this task was to remove the pop-over text which described what a viewer is.  It would be present in #72 and master, but not here.