### PR TITLE
Fix Assessment share token migration

### DIFF
--- a/db/migrate/20160204224626_share_token_assessments.rb
+++ b/db/migrate/20160204224626_share_token_assessments.rb
@@ -2,7 +2,7 @@ class ShareTokenAssessments < ActiveRecord::Migration
   def up
     Assessment.all.each do |assessment|
       assessment.ensure_share_token
-      assessment.save!
+      assessment.update_columns(share_token: assessment.share_token)
     end
   end
 


### PR DESCRIPTION
Migrations are currently failing because in staging we have assessments without district.