### PR TITLE
Adjusting the inventory models schema

### DIFF
--- a/app/models/data_entry.rb
+++ b/app/models/data_entry.rb
@@ -2,13 +2,10 @@
 #
 # Table name: data_entries
 #
-#  id                       :integer          not null, primary key
-#  general_data_question_id :integer          not null
-#  data_entry_question_id   :integer          not null
-#  data_access_question_id  :integer          not null
-#  created_at               :datetime
-#  updated_at               :datetime
-#  inventory_id             :integer
+#  id           :integer          not null, primary key
+#  created_at   :datetime
+#  updated_at   :datetime
+#  inventory_id :integer
 #
 
 class DataEntry < ActiveRecord::Base

--- a/app/models/data_entry_question.rb
+++ b/app/models/data_entry_question.rb
@@ -13,6 +13,8 @@
 
 class DataEntryQuestion < ActiveRecord::Base
 
+  belongs_to :data_entry
+
   enum data_entered_frequency: {
       yearly: 'Yearly',
       quarterly: 'Quarterly',

--- a/app/models/general_inventory_question.rb
+++ b/app/models/general_inventory_question.rb
@@ -18,6 +18,8 @@
 
 class GeneralInventoryQuestion < ActiveRecord::Base
 
+  belongs_to :product_entry
+
   enum product_type: {
       academic_content: 'PD for Academic Content',
       instructional_skills: 'PD for Instructional Skills',

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -15,8 +15,4 @@ class Inventory < ActiveRecord::Base
 
   accepts_nested_attributes_for :product_entries
   accepts_nested_attributes_for :data_entries
-
-  default_scope {
-    includes(:product_entries, :data_entries)
-  }
 end

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -2,23 +2,21 @@
 #
 # Table name: inventories
 #
-#  id               :integer          not null, primary key
-#  name             :string           not null
-#  deadline         :datetime         not null
-#  district_id      :integer          not null
-#  product_entry_id :integer
-#  data_entry_id    :integer
+#  id          :integer          not null, primary key
+#  name        :string           not null
+#  deadline    :datetime         not null
+#  district_id :integer          not null
 #
 
 class Inventory < ActiveRecord::Base
-  has_one :product_entry
-  has_one :data_entry
+  has_many :product_entries
+  has_many :data_entries
   belongs_to :district
 
-  accepts_nested_attributes_for :product_entry
-  accepts_nested_attributes_for :data_entry
+  accepts_nested_attributes_for :product_entries
+  accepts_nested_attributes_for :data_entries
 
   default_scope {
-    includes(:product_entry, :data_entry)
+    includes(:product_entries, :data_entries)
   }
 end

--- a/app/models/product_entry.rb
+++ b/app/models/product_entry.rb
@@ -2,14 +2,10 @@
 #
 # Table name: product_entries
 #
-#  id                            :integer          not null, primary key
-#  general_inventory_question_id :integer          not null
-#  product_question_id           :integer
-#  usage_question_id             :integer          not null
-#  technical_question_id         :integer          not null
-#  created_at                    :datetime
-#  updated_at                    :datetime
-#  inventory_id                  :integer
+#  id           :integer          not null, primary key
+#  created_at   :datetime
+#  updated_at   :datetime
+#  inventory_id :integer
 #
 
 class ProductEntry < ActiveRecord::Base

--- a/app/models/product_question.rb
+++ b/app/models/product_question.rb
@@ -14,6 +14,8 @@
 
 class ProductQuestion < ActiveRecord::Base
 
+  belongs_to :product_entry
+
   enum assignment_approach: {
       teacher_choice: 'Teacher Choice',
       data_driven: 'Data Driven',

--- a/app/models/technical_question.rb
+++ b/app/models/technical_question.rb
@@ -14,6 +14,8 @@
 
 class TechnicalQuestion < ActiveRecord::Base
 
+  belongs_to :product_entry
+
   enum platform: {
       browser: 'Browser Based',
       iphone: 'Native iPhone App',

--- a/db/migrate/20160303160639_remove_data_and_product_columns_from_inventory.rb
+++ b/db/migrate/20160303160639_remove_data_and_product_columns_from_inventory.rb
@@ -1,0 +1,6 @@
+class RemoveDataAndProductColumnsFromInventory < ActiveRecord::Migration
+  def change
+    remove_column :inventories, :data_entry_id
+    remove_column :inventories, :product_entry_id
+  end
+end

--- a/db/migrate/20160303160639_remove_data_and_product_columns_from_inventory.rb
+++ b/db/migrate/20160303160639_remove_data_and_product_columns_from_inventory.rb
@@ -1,6 +1,6 @@
 class RemoveDataAndProductColumnsFromInventory < ActiveRecord::Migration
   def change
-    remove_column :inventories, :data_entry_id
-    remove_column :inventories, :product_entry_id
+    remove_column :inventories, :data_entry_id, :integer
+    remove_column :inventories, :product_entry_id, :integer
   end
 end

--- a/db/migrate/20160303175531_remove_child_ids_from_data_and_product_entries.rb
+++ b/db/migrate/20160303175531_remove_child_ids_from_data_and_product_entries.rb
@@ -1,0 +1,12 @@
+class RemoveChildIdsFromDataAndProductEntries < ActiveRecord::Migration
+  def change
+    remove_column :product_entries, :general_inventory_question_id, :integer
+    remove_column :product_entries, :product_question_id, :integer
+    remove_column :product_entries, :usage_question_id, :integer
+    remove_column :product_entries, :technical_question_id, :integer
+
+    remove_column :data_entries, :general_data_question_id, :integer
+    remove_column :data_entries, :data_entry_question_id, :integer
+    remove_column :data_entries, :data_access_question_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160302204016) do
+ActiveRecord::Schema.define(version: 20160303160639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "access_requests", force: :cascade do |t|
     t.integer  "assessment_id"
@@ -249,15 +250,10 @@ ActiveRecord::Schema.define(version: 20160302204016) do
   add_index "general_inventory_questions", ["product_entry_id"], name: "index_general_inventory_questions_on_product_entry_id", using: :btree
 
   create_table "inventories", force: :cascade do |t|
-    t.string   "name",             null: false
-    t.datetime "deadline",         null: false
-    t.integer  "district_id",      null: false
-    t.integer  "product_entry_id"
-    t.integer  "data_entry_id"
+    t.string   "name",        null: false
+    t.datetime "deadline",    null: false
+    t.integer  "district_id", null: false
   end
-
-  add_index "inventories", ["data_entry_id"], name: "index_inventories_on_data_entry_id", using: :btree
-  add_index "inventories", ["product_entry_id"], name: "index_inventories_on_product_entry_id", using: :btree
 
   create_table "key_question_points", force: :cascade do |t|
     t.integer  "key_question_question_id"
@@ -450,7 +446,7 @@ ActiveRecord::Schema.define(version: 20160302204016) do
   add_index "scores", ["response_id", "question_id"], name: "index_scores_on_response_id_and_question_id", unique: true, using: :btree
 
   create_table "sessions", force: :cascade do |t|
-    t.string   "session_id", limit: 255, null: false
+    t.string   "session_id", null: false
     t.text     "data"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -551,8 +547,6 @@ ActiveRecord::Schema.define(version: 20160302204016) do
   add_foreign_key "data_entries", "data_access_questions", on_delete: :cascade
   add_foreign_key "data_entries", "data_entry_questions", on_delete: :cascade
   add_foreign_key "data_entries", "general_data_questions", on_delete: :cascade
-  add_foreign_key "inventories", "data_entries", on_delete: :cascade
-  add_foreign_key "inventories", "product_entries", on_delete: :cascade
   add_foreign_key "product_entries", "general_inventory_questions", on_delete: :cascade
   add_foreign_key "product_entries", "product_questions", on_delete: :cascade
   add_foreign_key "product_entries", "technical_questions", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160303160639) do
+ActiveRecord::Schema.define(version: 20160303175531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,17 +99,11 @@ ActiveRecord::Schema.define(version: 20160303160639) do
   add_index "data_access_questions", ["data_entry_id"], name: "index_data_access_questions_on_data_entry_id", using: :btree
 
   create_table "data_entries", force: :cascade do |t|
-    t.integer  "general_data_question_id", null: false
-    t.integer  "data_entry_question_id",   null: false
-    t.integer  "data_access_question_id",  null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "inventory_id"
   end
 
-  add_index "data_entries", ["data_access_question_id"], name: "index_data_entries_on_data_access_question_id", using: :btree
-  add_index "data_entries", ["data_entry_question_id"], name: "index_data_entries_on_data_entry_question_id", using: :btree
-  add_index "data_entries", ["general_data_question_id"], name: "index_data_entries_on_general_data_question_id", using: :btree
   add_index "data_entries", ["inventory_id"], name: "index_data_entries_on_inventory_id", using: :btree
 
   create_table "data_entry_questions", force: :cascade do |t|
@@ -330,20 +324,12 @@ ActiveRecord::Schema.define(version: 20160303160639) do
   end
 
   create_table "product_entries", force: :cascade do |t|
-    t.integer  "general_inventory_question_id", null: false
-    t.integer  "product_question_id"
-    t.integer  "usage_question_id",             null: false
-    t.integer  "technical_question_id",         null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "inventory_id"
   end
 
-  add_index "product_entries", ["general_inventory_question_id"], name: "index_product_entries_on_general_inventory_question_id", using: :btree
   add_index "product_entries", ["inventory_id"], name: "index_product_entries_on_inventory_id", using: :btree
-  add_index "product_entries", ["product_question_id"], name: "index_product_entries_on_product_question_id", using: :btree
-  add_index "product_entries", ["technical_question_id"], name: "index_product_entries_on_technical_question_id", using: :btree
-  add_index "product_entries", ["usage_question_id"], name: "index_product_entries_on_usage_question_id", using: :btree
 
   create_table "product_questions", force: :cascade do |t|
     t.text     "how_its_assigned", default: [], array: true
@@ -544,11 +530,4 @@ ActiveRecord::Schema.define(version: 20160303160639) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
-  add_foreign_key "data_entries", "data_access_questions", on_delete: :cascade
-  add_foreign_key "data_entries", "data_entry_questions", on_delete: :cascade
-  add_foreign_key "data_entries", "general_data_questions", on_delete: :cascade
-  add_foreign_key "product_entries", "general_inventory_questions", on_delete: :cascade
-  add_foreign_key "product_entries", "product_questions", on_delete: :cascade
-  add_foreign_key "product_entries", "technical_questions", on_delete: :cascade
-  add_foreign_key "product_entries", "usage_questions", on_delete: :cascade
 end

--- a/spec/factories/data_entries.rb
+++ b/spec/factories/data_entries.rb
@@ -11,7 +11,7 @@
 FactoryGirl.define do
   factory :data_entry do
     association :general_data_question
-    association :data_entry_question, :yearly_frequency
+    association :data_entry_question
     association :data_access_question
   end
 end

--- a/spec/factories/data_entries.rb
+++ b/spec/factories/data_entries.rb
@@ -2,13 +2,10 @@
 #
 # Table name: data_entries
 #
-#  id                       :integer          not null, primary key
-#  general_data_question_id :integer          not null
-#  data_entry_question_id   :integer          not null
-#  data_access_question_id  :integer          not null
-#  created_at               :datetime
-#  updated_at               :datetime
-#  inventory_id             :integer
+#  id           :integer          not null, primary key
+#  created_at   :datetime
+#  updated_at   :datetime
+#  inventory_id :integer
 #
 
 FactoryGirl.define do

--- a/spec/factories/data_entry_questions.rb
+++ b/spec/factories/data_entry_questions.rb
@@ -13,8 +13,6 @@
 
 FactoryGirl.define do
   factory :data_entry_question do
-    trait :yearly_frequency do
-      when_data_is_entered DataEntryQuestion.data_entered_frequencies[:yearly]
-    end
+    when_data_is_entered DataEntryQuestion.data_entered_frequencies[:yearly]
   end
 end

--- a/spec/factories/inventories.rb
+++ b/spec/factories/inventories.rb
@@ -2,12 +2,10 @@
 #
 # Table name: inventories
 #
-#  id               :integer          not null, primary key
-#  name             :string           not null
-#  deadline         :datetime         not null
-#  district_id      :integer          not null
-#  product_entry_id :integer
-#  data_entry_id    :integer
+#  id          :integer          not null, primary key
+#  name        :string           not null
+#  deadline    :datetime         not null
+#  district_id :integer          not null
 #
 
 FactoryGirl.define do

--- a/spec/factories/product_entries.rb
+++ b/spec/factories/product_entries.rb
@@ -11,6 +11,7 @@
 FactoryGirl.define do
   factory :product_entry do
     association :general_inventory_question
+    association :product_question
     association :usage_question
     association :technical_question
   end

--- a/spec/factories/product_entries.rb
+++ b/spec/factories/product_entries.rb
@@ -2,14 +2,10 @@
 #
 # Table name: product_entries
 #
-#  id                            :integer          not null, primary key
-#  general_inventory_question_id :integer          not null
-#  product_question_id           :integer
-#  usage_question_id             :integer          not null
-#  technical_question_id         :integer          not null
-#  created_at                    :datetime
-#  updated_at                    :datetime
-#  inventory_id                  :integer
+#  id           :integer          not null, primary key
+#  created_at   :datetime
+#  updated_at   :datetime
+#  inventory_id :integer
 #
 
 FactoryGirl.define do

--- a/spec/factories/product_questions.rb
+++ b/spec/factories/product_questions.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: product_questions
+#
+#  id               :integer          not null, primary key
+#  how_its_assigned :text             default([]), is an Array
+#  how_its_used     :text             default([]), is an Array
+#  how_its_accessed :text             default([]), is an Array
+#  audience         :text             default([]), is an Array
+#  created_at       :datetime
+#  updated_at       :datetime
+#  product_entry_id :integer
+#
+
+FactoryGirl.define do
+  factory :product_question do
+    how_its_assigned ProductQuestion.assignment_approaches[:teacher_choice]
+    how_its_used ProductQuestion.usage_frequencies[:blended]
+    how_its_accessed ProductQuestion.accesses[:video_share]
+    audience ProductQuestion.audience_types[:admin_audience]
+  end
+end

--- a/spec/models/data_access_question_spec.rb
+++ b/spec/models/data_access_question_spec.rb
@@ -13,16 +13,8 @@
 #  data_entry_id        :integer
 #
 
-class DataAccessQuestion < ActiveRecord::Base
+require 'spec_helper'
 
-  belongs_to :data_entry
-
-  enum data_accessed_by: {
-      team: 'Team',
-      central_office: 'Central Office',
-      school_district: 'School District',
-      public_access: 'Public',
-      other: 'Other'
-  }
-
+describe DataAccessQuestion do
+  it { is_expected.to belong_to(:data_entry) }
 end

--- a/spec/models/data_access_question_spec.rb
+++ b/spec/models/data_access_question_spec.rb
@@ -17,4 +17,10 @@ require 'spec_helper'
 
 describe DataAccessQuestion do
   it { is_expected.to belong_to(:data_entry) }
+
+  describe '#save' do
+    subject { FactoryGirl.create(:data_access_question) }
+
+    it { expect(subject.new_record?).to be false }
+  end
 end

--- a/spec/models/data_entry_question_spec.rb
+++ b/spec/models/data_entry_question_spec.rb
@@ -14,10 +14,13 @@
 require 'spec_helper'
 
 describe DataEntryQuestion do
-  it {is_expected.not_to allow_value('foo').for(:when_data_is_entered) }
 
-  DataEntryQuestion.data_entered_frequencies.values.each {|frequency|
-    it {is_expected.to allow_value(frequency).for(:when_data_is_entered) }
+  it { is_expected.to belong_to(:data_entry) }
+
+  it { is_expected.not_to allow_value('foo').for(:when_data_is_entered) }
+
+  DataEntryQuestion.data_entered_frequencies.values.each { |frequency|
+    it { is_expected.to allow_value(frequency).for(:when_data_is_entered) }
   }
 
 end

--- a/spec/models/data_entry_spec.rb
+++ b/spec/models/data_entry_spec.rb
@@ -19,7 +19,13 @@ describe DataEntry do
 
   it { is_expected.to validate_presence_of(:general_data_question) }
 
-  it { is_expected.to accept_nested_attributes_for(:general_data_question)}
-  it { is_expected.to accept_nested_attributes_for(:data_entry_question)}
-  it { is_expected.to accept_nested_attributes_for(:data_access_question)}
+  it { is_expected.to accept_nested_attributes_for(:general_data_question) }
+  it { is_expected.to accept_nested_attributes_for(:data_entry_question) }
+  it { is_expected.to accept_nested_attributes_for(:data_access_question) }
+
+  describe '#save' do
+    subject { FactoryGirl.create(:data_entry) }
+
+    it { expect(subject.new_record?).to be false }
+  end
 end

--- a/spec/models/data_entry_spec.rb
+++ b/spec/models/data_entry_spec.rb
@@ -2,13 +2,10 @@
 #
 # Table name: data_entries
 #
-#  id                       :integer          not null, primary key
-#  general_data_question_id :integer          not null
-#  data_entry_question_id   :integer          not null
-#  data_access_question_id  :integer          not null
-#  created_at               :datetime
-#  updated_at               :datetime
-#  inventory_id             :integer
+#  id           :integer          not null, primary key
+#  created_at   :datetime
+#  updated_at   :datetime
+#  inventory_id :integer
 #
 
 require 'spec_helper'

--- a/spec/models/general_data_question_spec.rb
+++ b/spec/models/general_data_question_spec.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: general_data_questions
+#
+#  id                          :integer          not null, primary key
+#  subcategory                 :string
+#  point_of_contact_name       :string
+#  point_of_contact_department :string
+#  data_capture                :string
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  data_entry_id               :integer
+#
+
+require 'spec_helper'
+
+describe GeneralDataQuestion do
+  it {is_expected.to belong_to(:data_entry) }
+end

--- a/spec/models/general_data_question_spec.rb
+++ b/spec/models/general_data_question_spec.rb
@@ -16,4 +16,10 @@ require 'spec_helper'
 
 describe GeneralDataQuestion do
   it {is_expected.to belong_to(:data_entry) }
+
+  describe '#save' do
+    subject { FactoryGirl.create(:general_data_question) }
+
+    it { expect(subject.new_record?).to be false }
+  end
 end

--- a/spec/models/general_inventory_question_spec.rb
+++ b/spec/models/general_inventory_question_spec.rb
@@ -20,6 +20,7 @@ require 'spec_helper'
 
 describe GeneralInventoryQuestion do
 
+  it { is_expected.to belong_to(:product_entry) }
   it { is_expected.to_not allow_value(['foo']).for(:data_type) }
   it { is_expected.to allow_value(GeneralInventoryQuestion.product_types.values).for(:data_type) }
 end

--- a/spec/models/general_inventory_question_spec.rb
+++ b/spec/models/general_inventory_question_spec.rb
@@ -23,4 +23,10 @@ describe GeneralInventoryQuestion do
   it { is_expected.to belong_to(:product_entry) }
   it { is_expected.to_not allow_value(['foo']).for(:data_type) }
   it { is_expected.to allow_value(GeneralInventoryQuestion.product_types.values).for(:data_type) }
+
+  describe '#save' do
+    subject { FactoryGirl.create(:general_inventory_question) }
+
+    it { expect(subject.new_record?).to be false }
+  end
 end

--- a/spec/models/inventory_spec.rb
+++ b/spec/models/inventory_spec.rb
@@ -2,23 +2,21 @@
 #
 # Table name: inventories
 #
-#  id               :integer          not null, primary key
-#  name             :string           not null
-#  deadline         :datetime         not null
-#  district_id      :integer          not null
-#  product_entry_id :integer
-#  data_entry_id    :integer
+#  id          :integer          not null, primary key
+#  name        :string           not null
+#  deadline    :datetime         not null
+#  district_id :integer          not null
 #
 
 require 'spec_helper'
 
 describe Inventory do
-  it { is_expected.to have_one(:product_entry) }
-  it { is_expected.to have_one(:data_entry) }
+  it { is_expected.to have_many(:product_entries) }
+  it { is_expected.to have_many(:data_entries) }
   it { is_expected.to belong_to(:district) }
 
-  it { is_expected.to accept_nested_attributes_for(:product_entry) }
-  it { is_expected.to accept_nested_attributes_for(:data_entry) }
+  it { is_expected.to accept_nested_attributes_for(:product_entries) }
+  it { is_expected.to accept_nested_attributes_for(:data_entries) }
 
   describe '#save' do
     subject { FactoryGirl.create(:inventory) }

--- a/spec/models/product_entry_spec.rb
+++ b/spec/models/product_entry_spec.rb
@@ -2,14 +2,10 @@
 #
 # Table name: product_entries
 #
-#  id                            :integer          not null, primary key
-#  general_inventory_question_id :integer          not null
-#  product_question_id           :integer
-#  usage_question_id             :integer          not null
-#  technical_question_id         :integer          not null
-#  created_at                    :datetime
-#  updated_at                    :datetime
-#  inventory_id                  :integer
+#  id           :integer          not null, primary key
+#  created_at   :datetime
+#  updated_at   :datetime
+#  inventory_id :integer
 #
 
 require 'spec_helper'

--- a/spec/models/product_entry_spec.rb
+++ b/spec/models/product_entry_spec.rb
@@ -26,4 +26,10 @@ describe ProductEntry do
   it { is_expected.to accept_nested_attributes_for(:product_question) }
   it { is_expected.to accept_nested_attributes_for(:usage_question) }
   it { is_expected.to accept_nested_attributes_for(:technical_question) }
+
+  describe '#save' do
+    subject { FactoryGirl.create(:product_entry) }
+
+    it { expect(subject.new_record?).to be false }
+  end
 end

--- a/spec/models/product_question_spec.rb
+++ b/spec/models/product_question_spec.rb
@@ -16,6 +16,7 @@ require 'spec_helper'
 
 describe ProductQuestion do
 
+  it { is_expected.to belong_to(:product_entry) }
   it { is_expected.not_to allow_value(['foo']).for(:how_its_assigned) }
   it { is_expected.not_to allow_value(['foo']).for(:how_its_used) }
   it { is_expected.not_to allow_value(['foo']).for(:how_its_accessed) }

--- a/spec/models/product_question_spec.rb
+++ b/spec/models/product_question_spec.rb
@@ -27,4 +27,10 @@ describe ProductQuestion do
   it { is_expected.to allow_value(ProductQuestion.accesses.values).for(:how_its_accessed) }
   it { is_expected.to allow_value(ProductQuestion.audience_types.values).for(:audience) }
 
+  describe '#save' do
+    subject { FactoryGirl.create(:product_question) }
+
+    it { expect(subject.new_record?).to be false }
+  end
+
 end

--- a/spec/models/technical_question_spec.rb
+++ b/spec/models/technical_question_spec.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: technical_questions
+#
+#  id               :integer          not null, primary key
+#  platform         :text             default([]), is an Array
+#  hosting          :text
+#  connectivity     :text
+#  single_sign_on   :text
+#  created_at       :datetime
+#  updated_at       :datetime
+#  product_entry_id :integer
+#
+
+require 'spec_helper'
+
+describe TechnicalQuestion do
+
+  it { is_expected.to belong_to(:product_entry) }
+
+end

--- a/spec/models/technical_question_spec.rb
+++ b/spec/models/technical_question_spec.rb
@@ -18,4 +18,9 @@ describe TechnicalQuestion do
 
   it { is_expected.to belong_to(:product_entry) }
 
+  describe '#save' do
+    subject { FactoryGirl.create(:technical_question) }
+
+    it { expect(subject.new_record?).to be false }
+  end
 end

--- a/spec/models/usage_question_spec.rb
+++ b/spec/models/usage_question_spec.rb
@@ -16,4 +16,10 @@ require 'spec_helper'
 
 describe UsageQuestion do
   it { is_expected.to belong_to(:product_entry) }
+
+  describe '#save' do
+    subject { FactoryGirl.create(:usage_question) }
+
+    it { expect(subject.new_record?).to be false }
+  end
 end

--- a/spec/models/usage_question_spec.rb
+++ b/spec/models/usage_question_spec.rb
@@ -12,6 +12,8 @@
 #  product_entry_id :integer
 #
 
-class UsageQuestion < ActiveRecord::Base
-  belongs_to :product_entry
+require 'spec_helper'
+
+describe UsageQuestion do
+  it { is_expected.to belong_to(:product_entry) }
 end

--- a/spec/support/util_helper.rb
+++ b/spec/support/util_helper.rb
@@ -3,7 +3,7 @@ def create_struct
 
   responder = Participant.create!(user: @user)
   rubric    = @rubric
-  response  = Response.create!(
+  response  = Response.find_or_create_by!(
     responder_type: 'Assessment',
     responder: responder,
     rubric: rubric,

--- a/spec/support/util_helper.rb
+++ b/spec/support/util_helper.rb
@@ -30,12 +30,12 @@ end
 
 
 def create_responses
-  response1    = Response.find_or_create_by!(
+  response1    = Response.create(
     responder_type: 'Participant',
     responder_id:   @participant.id,
     submitted_at: Time.now)
 
-  response2    = Response.find_or_create_by!(
+  response2    = Response.create(
     responder_type: 'Participant',
     responder_id:   @participant2.id,
     submitted_at: Time.now)

--- a/spec/support/util_helper.rb
+++ b/spec/support/util_helper.rb
@@ -30,12 +30,12 @@ end
 
 
 def create_responses
-  response1    = Response.create(
+  response1    = Response.find_or_create_by!(
     responder_type: 'Participant',
     responder_id:   @participant.id,
     submitted_at: Time.now)
 
-  response2    = Response.create(
+  response2    = Response.find_or_create_by!(
     responder_type: 'Participant',
     responder_id:   @participant2.id,
     submitted_at: Time.now)


### PR DESCRIPTION
This PR is good to go.  Notes: 

 - Removes unnecessary IDs in parent Inventory model
 - Add missing belongs_to relationships
 - Add spec tests to cover said relationships
 - Change Response.create! in util_helper to Response.find_or_create_by!