### PR TITLE
Hotfix: update due date

### DIFF
--- a/app/views/pdr_client/layouts/application.html.erb
+++ b/app/views/pdr_client/layouts/application.html.erb
@@ -10,20 +10,20 @@
   <body>
     <%= render 'pdr_client/layouts/partials/top_nav' %>
 
-    <div class="home-container container-fluid" ng-show="showFluid">
+    <div class="home-container container-fluid" ng-if="showFluid">
       <div class="row">
         <div class="col-md-12 view" ui-view="full-width">
         </div>
       </div>
     </div>
 
-    <div class="main-container container" ng-hide="showFluid">
+    <div class="main-container container" ng-if="!showFluid">
       <div class="row">
-        <div class="col-md-12 main-content" ui-view="full-width" ng-show="showFullWidth">
+        <div class="col-md-12 main-content" ui-view="full-width" ng-if="showFullWidth">
         </div>
       </div>
       <div class="row">
-        <div class="col-xs-12 col-md-9" ng-hide="showFullWidth">
+        <div class="col-xs-12 col-md-9" ng-if="!showFullWidth">
           <div class="main-content">
             <%= yield %>
           </div>


### PR DESCRIPTION
This PR is good to go. Notes:

 - This specifically addresses an issue in which we have two nodes on the DOM with the id 'due-date'.  This is due to the application HTML rendering elements when it shouldn't be (it was using ng-hide to visually hide them from the display instead).