### PR TITLE
Automatically add inventory owner as facilitator

### DIFF
--- a/app/authorizers/inventory_authorizer.rb
+++ b/app/authorizers/inventory_authorizer.rb
@@ -4,7 +4,7 @@ class InventoryAuthorizer < ApplicationAuthorizer
   end
 
   def updatable_by?(user)
-    resource.owner?(user: user) || resource.facilitator?(user: user)
+    resource.facilitator?(user: user)
   end
 
   def readable_by?(user)
@@ -12,6 +12,6 @@ class InventoryAuthorizer < ApplicationAuthorizer
   end
 
   def deletable_by?(user)
-    resource.owner?(user: user) || resource.facilitator?(user: user)
+    resource.facilitator?(user: user)
   end
 end

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -33,6 +33,8 @@ class Inventory < ActiveRecord::Base
   has_many :participants, -> { where(role: 'participant') }, class_name:'InventoryMember'
   has_many :facilitators, -> { where(role: 'facilitator') }, class_name:'InventoryMember'
 
+  after_create :add_facilitator_owner
+
   def facilitator?(user:)
     facilitators.where(user: user).exists?
   end
@@ -47,5 +49,11 @@ class Inventory < ActiveRecord::Base
 
   def member?(user:)
     self.members.where(user: user).exists?
+  end
+
+  private
+  def add_facilitator_owner
+    return unless owner
+    facilitators.create(user: owner)
   end
 end

--- a/spec/controllers/v1/inventory_permissions_controller_spec.rb
+++ b/spec/controllers/v1/inventory_permissions_controller_spec.rb
@@ -62,7 +62,7 @@ describe V1::InventoryPermissionsController do
       it { expect(response).to have_http_status(:success) }
 
       it 'changed all roles' do 
-        expect(inventory.facilitators.map(&:user).map(&:email)).to match original_participant_emails
+        expect(inventory.facilitators.map(&:user).map(&:email)).to include *original_participant_emails
       end
     end
   end

--- a/spec/factories/inventories.rb
+++ b/spec/factories/inventories.rb
@@ -24,7 +24,7 @@ FactoryGirl.define do
       end
 
       after(:create) do |inventory, evaluator|
-        inventory.members = FactoryGirl.create_list(:inventory_member, evaluator.members)
+        inventory.members << FactoryGirl.create_list(:inventory_member, evaluator.members)
       end
     end
 

--- a/spec/lib/inventories/permission_spec.rb
+++ b/spec/lib/inventories/permission_spec.rb
@@ -120,7 +120,7 @@ describe Inventories::Permission do
   describe '#available_permissions' do
     context 'as participant' do
       let(:inventory) { FactoryGirl.create(:inventory, :with_participants) }
-      let(:user) { inventory.members.first.user }
+      let(:user) { inventory.participants.first.user }
 
       subject { Inventories::Permission.new(inventory: inventory, user: user) }
 

--- a/spec/models/inventory_spec.rb
+++ b/spec/models/inventory_spec.rb
@@ -52,11 +52,13 @@ describe Inventory do
   end
 
   describe '#save' do
-    subject {
-      create(:inventory)
-    }
+    let(:owner) { FactoryGirl.create(:user) }
+    subject { FactoryGirl.create(:inventory, owner: owner) }
 
-    it { expect(subject.new_record?).to be false } 
+    it { expect(subject.new_record?).to be false }
+    it 'add owner as facilitator' do
+      expect(subject.facilitators.where(user: owner)).to exist
+    end
   end
 
   describe '#owner?' do


### PR DESCRIPTION
The owner of the inventory should automatically become a member facilitator of the inventory upon creation, this cover most of the scenarios involving all facilitators of the inventory for notifications and  authorization.

We want to have this common behavior in place by default to avoid [spreading it all around the project](https://github.com/MobilityLabs/pdredesign-server/blob/staging/app/workers/access_request_notification_worker.rb#L17).