### PR TITLE
Closes #163: Migrate over all inventory string fields to text

### DIFF
--- a/app/models/data_access_question.rb
+++ b/app/models/data_access_question.rb
@@ -3,11 +3,11 @@
 # Table name: data_access_questions
 #
 #  id                   :integer          not null, primary key
-#  data_storage         :string
-#  who_access_data      :string
-#  how_data_is_accessed :string
-#  why_data_is_accessed :string
-#  notes                :string
+#  data_storage         :text
+#  who_access_data      :text
+#  how_data_is_accessed :text
+#  why_data_is_accessed :text
+#  notes                :text
 #  created_at           :datetime
 #  updated_at           :datetime
 #  data_entry_id        :integer

--- a/app/models/data_entry_question.rb
+++ b/app/models/data_entry_question.rb
@@ -3,9 +3,9 @@
 # Table name: data_entry_questions
 #
 #  id                   :integer          not null, primary key
-#  who_enters_data      :string
-#  how_data_is_entered  :string
-#  when_data_is_entered :string
+#  who_enters_data      :text
+#  how_data_is_entered  :text
+#  when_data_is_entered :text
 #  created_at           :datetime
 #  updated_at           :datetime
 #  data_entry_id        :integer

--- a/app/models/general_data_question.rb
+++ b/app/models/general_data_question.rb
@@ -3,10 +3,10 @@
 # Table name: general_data_questions
 #
 #  id                          :integer          not null, primary key
-#  subcategory                 :string
-#  point_of_contact_name       :string
-#  point_of_contact_department :string
-#  data_capture                :string
+#  subcategory                 :text
+#  point_of_contact_name       :text
+#  point_of_contact_department :text
+#  data_capture                :text
 #  created_at                  :datetime
 #  updated_at                  :datetime
 #  data_entry_id               :integer

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -3,7 +3,7 @@
 # Table name: inventories
 #
 #  id          :integer          not null, primary key
-#  name        :string           not null
+#  name        :text             not null
 #  deadline    :datetime         not null
 #  district_id :integer          not null
 #  created_at  :datetime         not null

--- a/db/migrate/20160401210935_change_inventory_model_string_fields_to_text.rb
+++ b/db/migrate/20160401210935_change_inventory_model_string_fields_to_text.rb
@@ -1,0 +1,20 @@
+class ChangeInventoryModelStringFieldsToText < ActiveRecord::Migration
+  def change
+    change_column :data_access_questions, :data_storage, :text
+    change_column :data_access_questions, :who_access_data, :text
+    change_column :data_access_questions, :how_data_is_accessed, :text
+    change_column :data_access_questions, :why_data_is_accessed, :text
+    change_column :data_access_questions, :notes, :text
+
+    change_column :data_entry_questions, :who_enters_data, :text
+    change_column :data_entry_questions, :how_data_is_entered, :text
+    change_column :data_entry_questions, :when_data_is_entered, :text
+
+    change_column :general_data_questions, :subcategory, :text
+    change_column :general_data_questions, :point_of_contact_name, :text
+    change_column :general_data_questions, :point_of_contact_department, :text
+    change_column :general_data_questions, :data_capture, :text
+
+    change_column :inventories, :name, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160308011005) do
+ActiveRecord::Schema.define(version: 20160401210935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,11 +85,11 @@ ActiveRecord::Schema.define(version: 20160308011005) do
   end
 
   create_table "data_access_questions", force: :cascade do |t|
-    t.string   "data_storage"
-    t.string   "who_access_data"
-    t.string   "how_data_is_accessed"
-    t.string   "why_data_is_accessed"
-    t.string   "notes"
+    t.text     "data_storage"
+    t.text     "who_access_data"
+    t.text     "how_data_is_accessed"
+    t.text     "why_data_is_accessed"
+    t.text     "notes"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "data_entry_id"
@@ -106,9 +106,9 @@ ActiveRecord::Schema.define(version: 20160308011005) do
   add_index "data_entries", ["inventory_id"], name: "index_data_entries_on_inventory_id", using: :btree
 
   create_table "data_entry_questions", force: :cascade do |t|
-    t.string   "who_enters_data"
-    t.string   "how_data_is_entered"
-    t.string   "when_data_is_entered"
+    t.text     "who_enters_data"
+    t.text     "how_data_is_entered"
+    t.text     "when_data_is_entered"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "data_entry_id"
@@ -215,10 +215,10 @@ ActiveRecord::Schema.define(version: 20160308011005) do
   end
 
   create_table "general_data_questions", force: :cascade do |t|
-    t.string   "subcategory"
-    t.string   "point_of_contact_name"
-    t.string   "point_of_contact_department"
-    t.string   "data_capture"
+    t.text     "subcategory"
+    t.text     "point_of_contact_name"
+    t.text     "point_of_contact_department"
+    t.text     "data_capture"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "data_entry_id"
@@ -243,12 +243,12 @@ ActiveRecord::Schema.define(version: 20160308011005) do
   add_index "general_inventory_questions", ["product_entry_id"], name: "index_general_inventory_questions_on_product_entry_id", using: :btree
 
   create_table "inventories", force: :cascade do |t|
-    t.string   "name",        null: false
+    t.text     "name",        null: false
     t.datetime "deadline",    null: false
     t.integer  "district_id", null: false
-    t.integer  "owner_id"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.integer  "owner_id"
   end
 
   create_table "inventory_access_requests", force: :cascade do |t|
@@ -469,7 +469,7 @@ ActiveRecord::Schema.define(version: 20160308011005) do
   add_index "scores", ["response_id", "question_id"], name: "index_scores_on_response_id_and_question_id", unique: true, using: :btree
 
   create_table "sessions", force: :cascade do |t|
-    t.string   "session_id", limit: 255, null: false
+    t.string   "session_id", null: false
     t.text     "data"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/spec/factories/data_access_questions.rb
+++ b/spec/factories/data_access_questions.rb
@@ -3,11 +3,11 @@
 # Table name: data_access_questions
 #
 #  id                   :integer          not null, primary key
-#  data_storage         :string
-#  who_access_data      :string
-#  how_data_is_accessed :string
-#  why_data_is_accessed :string
-#  notes                :string
+#  data_storage         :text
+#  who_access_data      :text
+#  how_data_is_accessed :text
+#  why_data_is_accessed :text
+#  notes                :text
 #  created_at           :datetime
 #  updated_at           :datetime
 #  data_entry_id        :integer

--- a/spec/factories/data_entry_questions.rb
+++ b/spec/factories/data_entry_questions.rb
@@ -3,9 +3,9 @@
 # Table name: data_entry_questions
 #
 #  id                   :integer          not null, primary key
-#  who_enters_data      :string
-#  how_data_is_entered  :string
-#  when_data_is_entered :string
+#  who_enters_data      :text
+#  how_data_is_entered  :text
+#  when_data_is_entered :text
 #  created_at           :datetime
 #  updated_at           :datetime
 #  data_entry_id        :integer

--- a/spec/factories/general_data_questions.rb
+++ b/spec/factories/general_data_questions.rb
@@ -3,16 +3,14 @@
 # Table name: general_data_questions
 #
 #  id                          :integer          not null, primary key
-#  subcategory                 :string
-#  point_of_contact_name       :string
-#  point_of_contact_department :string
-#  data_capture                :string
+#  subcategory                 :text
+#  point_of_contact_name       :text
+#  point_of_contact_department :text
+#  data_capture                :text
 #  created_at                  :datetime
 #  updated_at                  :datetime
 #  data_entry_id               :integer
 #
-
-
 
 FactoryGirl.define do
   factory :general_data_question

--- a/spec/factories/inventories.rb
+++ b/spec/factories/inventories.rb
@@ -3,7 +3,7 @@
 # Table name: inventories
 #
 #  id          :integer          not null, primary key
-#  name        :string           not null
+#  name        :text             not null
 #  deadline    :datetime         not null
 #  district_id :integer          not null
 #  created_at  :datetime         not null

--- a/spec/models/data_access_question_spec.rb
+++ b/spec/models/data_access_question_spec.rb
@@ -3,11 +3,11 @@
 # Table name: data_access_questions
 #
 #  id                   :integer          not null, primary key
-#  data_storage         :string
-#  who_access_data      :string
-#  how_data_is_accessed :string
-#  why_data_is_accessed :string
-#  notes                :string
+#  data_storage         :text
+#  who_access_data      :text
+#  how_data_is_accessed :text
+#  why_data_is_accessed :text
+#  notes                :text
 #  created_at           :datetime
 #  updated_at           :datetime
 #  data_entry_id        :integer

--- a/spec/models/data_entry_question_spec.rb
+++ b/spec/models/data_entry_question_spec.rb
@@ -3,9 +3,9 @@
 # Table name: data_entry_questions
 #
 #  id                   :integer          not null, primary key
-#  who_enters_data      :string
-#  how_data_is_entered  :string
-#  when_data_is_entered :string
+#  who_enters_data      :text
+#  how_data_is_entered  :text
+#  when_data_is_entered :text
 #  created_at           :datetime
 #  updated_at           :datetime
 #  data_entry_id        :integer

--- a/spec/models/general_data_question_spec.rb
+++ b/spec/models/general_data_question_spec.rb
@@ -3,10 +3,10 @@
 # Table name: general_data_questions
 #
 #  id                          :integer          not null, primary key
-#  subcategory                 :string
-#  point_of_contact_name       :string
-#  point_of_contact_department :string
-#  data_capture                :string
+#  subcategory                 :text
+#  point_of_contact_name       :text
+#  point_of_contact_department :text
+#  data_capture                :text
 #  created_at                  :datetime
 #  updated_at                  :datetime
 #  data_entry_id               :integer

--- a/spec/models/inventory_spec.rb
+++ b/spec/models/inventory_spec.rb
@@ -3,7 +3,7 @@
 # Table name: inventories
 #
 #  id          :integer          not null, primary key
-#  name        :string           not null
+#  name        :text             not null
 #  deadline    :datetime         not null
 #  district_id :integer          not null
 #  created_at  :datetime         not null


### PR DESCRIPTION
This PR is good to go.  Notes:

 - This only changes the inventory questionnaire-related models' columns over from string to text.
 - No data should be destroyed with this migration, but that should be double checked.