### PR TITLE
165 product entries connectivity

### DIFF
--- a/app/assets/javascripts/client/forms/searchableList.js
+++ b/app/assets/javascripts/client/forms/searchableList.js
@@ -1,0 +1,37 @@
+(function() {
+  'use strict';
+  angular.module('PDRClient')
+      .directive('searchableList', searchableList);
+  
+  function searchableList () {
+    return {
+      restrict: 'E',
+      scope: {
+        title: '@'
+      },
+      replace: true,
+      transclude: true,
+      templateUrl: 'client/forms/searchable_list.html',
+      link: searchableListLink
+    }
+  };
+
+  function searchableListLink (scope, element, attrs, controller) {
+    element.find('.search').on('input', function (event) {
+      element.find('.list > div').addClass('javascripted');
+      element.find('.list > div').removeClass('odd');
+
+      var searchTerm = event.currentTarget.value;
+      
+      _.each( element.find('.list').children(), function (listItemElement) {
+         if (listItemElement.innerText.match(searchTerm) === null) {
+          $(listItemElement).hide();
+         } else {
+          $(listItemElement).show();
+         }
+      });
+
+      element.find('.list > div:visible:even').addClass('odd');
+    });
+  };
+})();

--- a/app/assets/javascripts/client/forms/searchable_list.html
+++ b/app/assets/javascripts/client/forms/searchable_list.html
@@ -1,0 +1,7 @@
+<div class="searchable-list">
+  <div class="list-header">
+    <strong>{{title}}</strong>
+    <input type="text" placeholder="Search" class="search">
+  </div>
+  <div ng-transclude class="list"></div>
+</div>

--- a/app/assets/javascripts/client/inventories/Inventory.js
+++ b/app/assets/javascripts/client/inventories/Inventory.js
@@ -20,6 +20,10 @@
       },
       'save': {
         method: 'PUT'
+      },
+      'districtProductEntries': {
+        method: 'GET',
+        url: UrlService.url('inventories/:inventory_id/district_product_entries')
       }
     };
 

--- a/app/assets/javascripts/client/inventories/ProductEntryModalCtrl.js
+++ b/app/assets/javascripts/client/inventories/ProductEntryModalCtrl.js
@@ -8,10 +8,11 @@
     '$scope',
     'ProductEntry',
     'ConstantsService',
-    'CheckboxService'
+    'CheckboxService',
+    'Inventory'
   ];
 
-  function ProductEntryModalCtrl($scope, ProductEntry, ConstantsService, CheckboxService) {
+  function ProductEntryModalCtrl($scope, ProductEntry, ConstantsService, CheckboxService, Inventory) {
     var vm = this;
 
     vm.closeModal = function() {
@@ -79,7 +80,29 @@
         vm.productEntry.technical_question,
         'platforms'
       );
-    }
+
+      Inventory.districtProductEntries({inventory_id: vm.inventory.id})
+          .$promise.then(function (response) {
+            vm.districtProductEntries = response.product_entries;
+
+            var options = _.reduce(response.product_entries, function (result, productEntry) {
+              result[productEntry.id] = productEntry.id;
+              return result;
+            }, {});
+
+            CheckboxService.checkboxize(
+              $scope,
+              'selectedConnectedProductEntries',
+              options,
+              vm.productEntry.technical_question,
+              'connectivity'
+            );
+          });
+    };
+
+    vm.getProductEntryName = function (id) {
+      return _.findWhere(vm.districtProductEntries, {id: id}).general_inventory_question.product_name;
+    };
 
     vm.save = function () {
       var productEntry = angular.copy( vm.productEntry );

--- a/app/assets/javascripts/client/inventories/product_entry_modal.html
+++ b/app/assets/javascripts/client/inventories/product_entry_modal.html
@@ -296,6 +296,24 @@
       </div>
     </div>
     <div class='row'>
+      <div class='col-sm-12'>
+        <div class='form-group'>
+          <label>
+            Connectivity
+            <span class='field-info'>What other products or data systems is this connected to?</span>
+          </label>
+          <searchable-list title="{{selectedConnectedProductEntries.length}} Products">
+            <div ng-repeat='selectedConnectedProductEntry in selectedConnectedProductEntries' class='control-list'>
+              <label>
+                <fake-checkbox model='selectedConnectedProductEntry.selected'></fake-checkbox>
+                {{productEntryModal.getProductEntryName(selectedConnectedProductEntry.name)}}
+              </label>
+            </div>
+          </searchable-list>
+        </div>
+      </div>
+    </div>
+    <div class='row'>
       <div class='col-sm-6'>
         <div class='form-group'>
           <label for='product-entry-sign-on'>

--- a/app/assets/stylesheets/directives/searchable-list.sass
+++ b/app/assets/stylesheets/directives/searchable-list.sass
@@ -1,18 +1,20 @@
+$grey: #EBECF0
+
 .searchable-list
   height: 200px
   display: flex
   flex-direction: column
   overflow: hidden
-  border: 1px solid lightgray
+  border: 1px solid grey
 
   .list-header
     flex: 0 0 auto
     display: flex
     justify-content: space-between
     align-items: center
-    padding: 2px 2px 2px 5px
-    background-color: lightgray
-    border-bottom: 1px solid lightgray
+    padding: 5px
+    background-color: $grey
+    border-bottom: 1px solid grey
 
     .search
       background-color: white !important
@@ -28,4 +30,4 @@
 
       &:not(.javascripted):nth-child(odd),
       &.odd
-        background-color: lightgray
+        background-color: $grey

--- a/app/assets/stylesheets/directives/searchable-list.sass
+++ b/app/assets/stylesheets/directives/searchable-list.sass
@@ -1,0 +1,31 @@
+.searchable-list
+  height: 200px
+  display: flex
+  flex-direction: column
+  overflow: hidden
+  border: 1px solid lightgray
+
+  .list-header
+    flex: 0 0 auto
+    display: flex
+    justify-content: space-between
+    align-items: center
+    padding: 2px 2px 2px 5px
+    background-color: lightgray
+    border-bottom: 1px solid lightgray
+
+    .search
+      background-color: white !important
+
+  .list
+    overflow: auto
+
+    *
+      margin: 0
+
+    > div
+      padding: 3px 0
+
+      &:not(.javascripted):nth-child(odd),
+      &.odd
+        background-color: lightgray

--- a/app/assets/stylesheets/imports.css.sass
+++ b/app/assets/stylesheets/imports.css.sass
@@ -33,6 +33,7 @@
 @import 'directives/tabs'
 @import 'directives/fake-checkbox'
 @import 'directives/fake-radio'
+@import 'directives/searchable-list'
 
 @import 'modals/response_submit'
 @import 'modals/invite_user'

--- a/app/controllers/v1/inventories_controller.rb
+++ b/app/controllers/v1/inventories_controller.rb
@@ -47,6 +47,16 @@ class V1::InventoriesController < ApplicationController
     end
   end
 
+  def district_product_entries
+    # FIXME extract to service or member mehtods
+    inventory = Inventory.find(params[:id])
+    inventories = Inventory.where(district: inventory.district)
+
+    @product_entries = ProductEntry.where(inventory: inventories)
+
+    render template: 'v1/product_entries/index'
+  end
+
   private
   def inventory_params
     params.require(:inventory).permit(:name, :deadline, :district_id, district: [:id])

--- a/app/controllers/v1/inventories_controller.rb
+++ b/app/controllers/v1/inventories_controller.rb
@@ -48,11 +48,7 @@ class V1::InventoriesController < ApplicationController
   end
 
   def district_product_entries
-    # FIXME extract to service or member mehtods
-    inventory = Inventory.find(params[:id])
-    inventories = Inventory.where(district: inventory.district)
-
-    @product_entries = ProductEntry.where(inventory: inventories)
+    @product_entries = ProductEntry.for_district(params[:id])
 
     render template: 'v1/product_entries/index'
   end

--- a/app/controllers/v1/product_entries_controller.rb
+++ b/app/controllers/v1/product_entries_controller.rb
@@ -65,7 +65,7 @@ class V1::ProductEntriesController < ApplicationController
       technical_question_attributes: [
         {platforms: []},
         :hosting,
-        :connectivity,
+        {connectivity: []},
         :single_sign_on
       ],
       general_inventory_question_attributes: [

--- a/app/models/product_entry.rb
+++ b/app/models/product_entry.rb
@@ -38,4 +38,13 @@ class ProductEntry < ActiveRecord::Base
   default_scope {
     includes(:general_inventory_question, :product_question, :usage_question, :technical_question)
   }
+
+  scope :for_district, -> (district_id) {
+    joins(:inventory).
+    where(inventories: {
+      district_id: Inventory.select(:district_id).where(id: district_id)
+    }).
+    uniq
+  }
+  
 end

--- a/app/models/technical_question.rb
+++ b/app/models/technical_question.rb
@@ -5,7 +5,7 @@
 #  id               :integer          not null, primary key
 #  platforms         :text            default([]), is an Array
 #  hosting          :text
-#  connectivity     :text
+#  connectivity     :integer          default([], is an Array
 #  single_sign_on   :text
 #  created_at       :datetime
 #  updated_at       :datetime

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,10 @@ PdrServer::Application.routes.draw do
           get 'exists', to: 'learning_questions#exists'
         end
       end
+
+      member do
+        get :district_product_entries
+      end
     end
 
     scope '/constants' do

--- a/db/migrate/20160412111252_change_technical_questions_connectivity_to_integer_array.rb
+++ b/db/migrate/20160412111252_change_technical_questions_connectivity_to_integer_array.rb
@@ -1,0 +1,5 @@
+class ChangeTechnicalQuestionsConnectivityToIntegerArray < ActiveRecord::Migration
+  def change
+    change_column :technical_questions, :connectivity, 'integer[] USING CAST(connectivity AS integer[])', default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160404201732) do
+ActiveRecord::Schema.define(version: 20160412111252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,10 +19,10 @@ ActiveRecord::Schema.define(version: 20160404201732) do
   create_table "access_requests", force: :cascade do |t|
     t.integer  "assessment_id"
     t.integer  "user_id"
-    t.string   "roles",         default: [], array: true
+    t.string   "roles",                     default: [], array: true
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "token"
+    t.string   "token",         limit: 255
   end
 
   create_table "answers", force: :cascade do |t|
@@ -140,10 +140,10 @@ ActiveRecord::Schema.define(version: 20160404201732) do
   end
 
   create_table "district_messages", force: :cascade do |t|
-    t.string   "name"
-    t.string   "address"
-    t.string   "sender_name"
-    t.string   "sender_email"
+    t.string   "name",         limit: 255
+    t.string   "address",      limit: 255
+    t.string   "sender_name",  limit: 255
+    t.string   "sender_email", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -188,14 +188,14 @@ ActiveRecord::Schema.define(version: 20160404201732) do
   end
 
   create_table "faq_categories", force: :cascade do |t|
-    t.string   "heading"
+    t.string   "heading",    limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "faq_questions", force: :cascade do |t|
-    t.string   "role"
-    t.string   "topic"
+    t.string   "role",        limit: 255
+    t.string   "topic",       limit: 255
     t.integer  "category_id"
     t.text     "content"
     t.text     "answer"
@@ -215,7 +215,7 @@ ActiveRecord::Schema.define(version: 20160404201732) do
   end
 
   create_table "general_data_questions", force: :cascade do |t|
-    t.text     "subcategory"
+    t.text     "data_type"
     t.text     "point_of_contact_name"
     t.text     "point_of_contact_department"
     t.text     "data_capture"
@@ -334,8 +334,8 @@ ActiveRecord::Schema.define(version: 20160404201732) do
   end
 
   create_table "organizations", force: :cascade do |t|
-    t.string "name"
-    t.string "logo"
+    t.string "name", limit: 255
+    t.string "logo", limit: 255
   end
 
   create_table "organizations_users", id: false, force: :cascade do |t|
@@ -471,7 +471,7 @@ ActiveRecord::Schema.define(version: 20160404201732) do
   add_index "scores", ["response_id", "question_id"], name: "index_scores_on_response_id_and_question_id", unique: true, using: :btree
 
   create_table "sessions", force: :cascade do |t|
-    t.string   "session_id", null: false
+    t.string   "session_id", limit: 255, null: false
     t.text     "data"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -483,7 +483,7 @@ ActiveRecord::Schema.define(version: 20160404201732) do
   create_table "technical_questions", force: :cascade do |t|
     t.text     "platforms",        default: [], array: true
     t.text     "hosting"
-    t.text     "connectivity"
+    t.integer  "connectivity",     default: [], array: true
     t.text     "single_sign_on"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -493,27 +493,27 @@ ActiveRecord::Schema.define(version: 20160404201732) do
   add_index "technical_questions", ["product_entry_id"], name: "index_technical_questions_on_product_entry_id", using: :btree
 
   create_table "tool_categories", force: :cascade do |t|
-    t.string  "title"
+    t.string  "title",         limit: 255
     t.integer "display_order"
     t.integer "tool_phase_id"
   end
 
   create_table "tool_phases", force: :cascade do |t|
-    t.string  "title"
+    t.string  "title",         limit: 255
     t.text    "description"
     t.integer "display_order"
   end
 
   create_table "tool_subcategories", force: :cascade do |t|
-    t.string  "title"
+    t.string  "title",            limit: 255
     t.integer "display_order"
     t.integer "tool_category_id"
   end
 
   create_table "tools", force: :cascade do |t|
-    t.string  "title"
+    t.string  "title",               limit: 255
     t.text    "description"
-    t.string  "url"
+    t.string  "url",                 limit: 255
     t.boolean "is_default"
     t.integer "display_order"
     t.integer "tool_subcategory_id"
@@ -534,11 +534,11 @@ ActiveRecord::Schema.define(version: 20160404201732) do
   add_index "usage_questions", ["product_entry_id"], name: "index_usage_questions_on_product_entry_id", using: :btree
 
   create_table "user_invitations", force: :cascade do |t|
-    t.string  "first_name"
-    t.string  "last_name"
-    t.string  "email"
-    t.string  "team_role"
-    t.string  "token"
+    t.string  "first_name",    limit: 255
+    t.string  "last_name",     limit: 255
+    t.string  "email",         limit: 255
+    t.string  "team_role",     limit: 255
+    t.string  "token",         limit: 255
     t.integer "assessment_id"
     t.integer "user_id"
   end

--- a/spec/factories/product_entries.rb
+++ b/spec/factories/product_entries.rb
@@ -10,6 +10,7 @@
 
 FactoryGirl.define do
   factory :product_entry do
+    association :inventory
     association :general_inventory_question
     association :product_question
     association :usage_question

--- a/spec/javascripts/directives/searchableListSpec.js
+++ b/spec/javascripts/directives/searchableListSpec.js
@@ -1,0 +1,85 @@
+(function() {
+  'use strict';
+
+  describe('Directive: searchableList', function() {
+    var $scope,
+        $compile,
+        element,
+        isolatedScope;
+
+    beforeEach(function() {
+      module('PDRClient');
+      inject(function(_$compile_, _$rootScope_) {
+        $compile = _$compile_;
+        $scope = _$rootScope_.$new(true);
+
+        element = angular.element('<searchable-list><div>foo</div><div>bar</div><div>foobar</div></searchable-list>');
+        document.body.appendChild(element[0]);
+        
+        $compile(element)($scope);
+        $scope.$digest();
+
+        isolatedScope = element.isolateScope();
+      });
+    });
+
+    afterEach(function () {
+      document.body.removeChild(element[0]);
+    });
+
+    describe('search', function () {
+      it('hides as it searches', function () {
+        expect(element.find('.list div:visible').length).toBe(3);
+        expect(element.find('.list div:nth-child(1)').is(':visible')).toBe(true);
+        expect(element.find('.list div:nth-child(2)').is(':visible')).toBe(true);
+        expect(element.find('.list div:nth-child(3)').is(':visible')).toBe(true);
+
+        element.find('.search').val('foo').trigger('input');
+        expect(element.find('.list div:visible').length).toBe(2);
+        expect(element.find('.list div:nth-child(1)').is(':visible')).toBe(true);
+        expect(element.find('.list div:nth-child(2)').is(':visible')).toBe(false);
+        expect(element.find('.list div:nth-child(3)').is(':visible')).toBe(true);
+
+        element.find('.search').val('foob').trigger('input');
+        expect(element.find('.list div:visible').length).toBe(1);
+        expect(element.find('.list div:nth-child(1)').is(':visible')).toBe(false);
+        expect(element.find('.list div:nth-child(2)').is(':visible')).toBe(false);
+        expect(element.find('.list div:nth-child(3)').is(':visible')).toBe(true);
+
+        element.find('.search').val('foobars').trigger('input');
+        expect(element.find('.list div:visible').length).toBe(0);
+        expect(element.find('.list div:nth-child(1)').is(':visible')).toBe(false);
+        expect(element.find('.list div:nth-child(2)').is(':visible')).toBe(false);
+        expect(element.find('.list div:nth-child(3)').is(':visible')).toBe(false);
+
+        element.find('.search').val('').trigger('input');
+        expect(element.find('.list div:visible').length).toBe(3);
+        expect(element.find('.list div:nth-child(1)').is(':visible')).toBe(true);
+        expect(element.find('.list div:nth-child(2)').is(':visible')).toBe(true);
+        expect(element.find('.list div:nth-child(3)').is(':visible')).toBe(true);
+      });
+
+      it('alternates row css classes as it searches', function () {
+        element.find('.search').val('foo').trigger('input');
+        expect(element.find('.list div:nth-child(1)').hasClass('odd')).toBe(true);
+        expect(element.find('.list div:nth-child(2)').hasClass('odd')).toBe(false);
+        expect(element.find('.list div:nth-child(3)').hasClass('odd')).toBe(false);
+
+        element.find('.search').val('foob').trigger('input');
+        expect(element.find('.list div:nth-child(1)').hasClass('odd')).toBe(false);
+        expect(element.find('.list div:nth-child(2)').hasClass('odd')).toBe(false);
+        expect(element.find('.list div:nth-child(3)').hasClass('odd')).toBe(true);
+
+        element.find('.search').val('foobars').trigger('input');
+        expect(element.find('.list div:nth-child(1)').hasClass('odd')).toBe(false);
+        expect(element.find('.list div:nth-child(2)').hasClass('odd')).toBe(false);
+        expect(element.find('.list div:nth-child(3)').hasClass('odd')).toBe(false);
+
+        element.find('.search').val('').trigger('input');
+        expect(element.find('.list div:nth-child(1)').hasClass('odd')).toBe(true);
+        expect(element.find('.list div:nth-child(2)').hasClass('odd')).toBe(false);
+        expect(element.find('.list div:nth-child(3)').hasClass('odd')).toBe(true);
+      });
+    });
+  });
+})();

--- a/spec/models/product_entry_spec.rb
+++ b/spec/models/product_entry_spec.rb
@@ -32,4 +32,28 @@ describe ProductEntry do
 
     it { expect(subject.new_record?).to be false }
   end
+
+  describe 'for district' do
+    let(:district1) { FactoryGirl.create(:district) }
+    let(:district2) { FactoryGirl.create(:district) }
+    it 'returns inventories from the district of a certain inventory_id' do
+      district1_inventory1 = FactoryGirl.create(:inventory, district: district1)
+      district1_inventory2 = FactoryGirl.create(:inventory, district: district1)
+      FactoryGirl.create(:inventory)
+
+      district1_inventory1_product_entry1 = FactoryGirl.create(:product_entry, inventory: district1_inventory1)
+      district1_inventory1_product_entry2 = FactoryGirl.create(:product_entry, inventory: district1_inventory1)
+      district1_inventory2_product_entry1 = FactoryGirl.create(:product_entry, inventory: district1_inventory2)
+      district1_inventory2_product_entry2 = FactoryGirl.create(:product_entry, inventory: district1_inventory2)
+
+      FactoryGirl.create(:product_entry)
+
+      expect(ProductEntry.for_district(district1_inventory1.id)).to match_array([
+        district1_inventory1_product_entry1,
+        district1_inventory1_product_entry2,
+        district1_inventory2_product_entry1,
+        district1_inventory2_product_entry2
+      ])
+    end
+  end
 end


### PR DESCRIPTION
closes #165 
I chose not to use the data tables for the connectivity section, because:
* it’s a list, not a table
* the only common functionality would be search

Instead, I created a `<searchable-list></searchable-list>` directive with transclusion which wraps around whatever list you like, and creates a search interface for it.

I'm not 100% convinced that the `district_product_entries` action belongs in `InventoriesController`, or that the `for_district` scope really sits well inside the `ProductEntry` model, so please do feel free to suggest a better place for those.