### PR TITLE
Closes #200: inventory invites

### DIFF
--- a/app/assets/javascripts/client/controllers/invitation/InvitationCtrl.js
+++ b/app/assets/javascripts/client/controllers/invitation/InvitationCtrl.js
@@ -14,6 +14,12 @@ PDRClient.controller('InvitationCtrl', [
       $scope.showalert    = false;
       $scope.alerts       = [];
 
+      var invitation_message = sessionStorage.getItem('invitation_message');
+      if(invitation_message) {
+        $scope.alerts.push({type: 'info', msg: invitation_message});
+        sessionStorage.removeItem('invitation_message');
+      }
+
       $scope.showError = function(msg) {
         $scope.alerts.push({type: 'danger', msg: msg});
       };

--- a/app/assets/javascripts/client/controllers/invitation/InvitationCtrl.js
+++ b/app/assets/javascripts/client/controllers/invitation/InvitationCtrl.js
@@ -53,8 +53,13 @@ PDRClient.controller('InvitationCtrl', [
               .authenticate($scope.inviteObject.email, $scope.inviteObject.password)
               .then(function(){
                 $rootScope.$broadcast('session_updated');
-                SessionService
-                  .syncAndRedirect('/assessments/' + $scope.invitedUser.assessment_id + '/responses');
+                var redirectUrl = null;
+                if($scope.invitedUser.inventory_id) {
+                  redirectUrl = '/inventories/' + $scope.invitedUser.inventory_id + '/edit';
+                } else {
+                  redirectUrl = '/assessments/' + $scope.invitedUser.assessment_id + '/responses';
+                }
+                SessionService.syncAndRedirect(redirectUrl);
               });
           }, function(response){
             $scope.populateErrors(response.data.errors)

--- a/app/assets/javascripts/client/directives/signup.js
+++ b/app/assets/javascripts/client/directives/signup.js
@@ -46,6 +46,11 @@ PDRClient.directive('signup', [
                     $scope.success = "User created";
                     $scope.login(user);
                   }, function(response) {
+                    if(response.data && response.data.base) {
+                      sessionStorage.setItem('invitation_message', response.data.base);
+                      $state.go('invite', {token: response.data.invitation_token});
+                      return;
+                    }
                     $scope.errors  = response.data.errors;
                   }
                 );

--- a/app/controllers/v1/invitations_controller.rb
+++ b/app/controllers/v1/invitations_controller.rb
@@ -18,10 +18,16 @@ class V1::InvitationsController < ApplicationController
     not_found    and return unless invitation
     unauthorized and return unless invited_user
 
-    render :show, locals: {
-      user: invited_user,
-      assessment_id: invitation.assessment_id
+    locals =  {
+      user: invited_user
     }
+    if invitation.is_a? InventoryInvitation
+      locals[:inventory_id] =  invitation.inventory_id
+    else
+      locals[:assessment_id] =  invitation.assessment_id
+    end
+
+    render :show, locals: locals
   end
 
   private
@@ -42,7 +48,7 @@ class V1::InvitationsController < ApplicationController
   end
 
   def find_invitation(token)
-    UserInvitation.find_by(token: token)
+    UserInvitation.find_by(token: token) || InventoryInvitation.find_by(token: token)
   end
 
 end

--- a/app/controllers/v1/user_controller.rb
+++ b/app/controllers/v1/user_controller.rb
@@ -17,8 +17,7 @@ class V1::UserController < ApplicationController
     if user_invitation.present?
       @user.errors.add(:base, "It seems you have already been invited. Please continue your registration here.")
       render json: @user.errors.to_h.merge(
-        invitation_token: user_invitation.token,
-        invitation_type: user_invitation.class.name.underscore
+        invitation_token: user_invitation.token
       ), status: :unprocessable_entity
     elsif @user.save
       send_notification_email

--- a/app/controllers/v1/user_controller.rb
+++ b/app/controllers/v1/user_controller.rb
@@ -7,12 +7,19 @@ class V1::UserController < ApplicationController
   end
 
   def create
-    @user                  = find_by_invite_or_initialize(user_params)
-    @user.role             = params[:role] || :member
-    @user.district_ids     = extract_ids_from_params(:district_ids)
-    @user.organization_ids = extract_ids_from_params(:organization_ids)
+    @user = User.create(user_params.merge(
+      role: params[:role] || :member,
+      district_ids: extract_ids_from_params(:district_ids),
+      organization_ids: extract_ids_from_params(:organization_ids)
+    ))
 
-    if @user.save
+    user_invitation = UserInvitation.find_by(email: user_params[:email])
+    if user_invitation.present?
+      @user.errors.add(:base, "It seems you have already been invited. Please continue your registration here.")
+      render json: @user.errors.to_h.merge(
+        invitation_token: user_invitation.token
+      ), status: :unprocessable_entity
+    elsif @user.save
       send_notification_email
       render status: 200, nothing: true
     else
@@ -61,18 +68,6 @@ class V1::UserController < ApplicationController
   end
 
   private
-  def find_by_invite_or_initialize(user_params)
-    user_invitation = UserInvitation.find_by(email: user_params[:email])
-    user            = User.new
-
-    if user_invitation
-      user = User.find_by(email: user_params[:email])
-      user_invitation.destroy
-    end
-
-    user.tap { |u| u.update_attributes(user_params) }
-  end
-
   def hash
     SecureRandom.hex[0..9]
   end

--- a/app/controllers/v1/user_controller.rb
+++ b/app/controllers/v1/user_controller.rb
@@ -13,11 +13,12 @@ class V1::UserController < ApplicationController
       organization_ids: extract_ids_from_params(:organization_ids)
     ))
 
-    user_invitation = UserInvitation.find_by(email: user_params[:email])
+    user_invitation = [UserInvitation.find_by(email: user_params[:email]), InventoryInvitation.find_by(email: user_params[:email])].find{|invitation| !invitation.nil?}
     if user_invitation.present?
       @user.errors.add(:base, "It seems you have already been invited. Please continue your registration here.")
       render json: @user.errors.to_h.merge(
-        invitation_token: user_invitation.token
+        invitation_token: user_invitation.token,
+        invitation_type: user_invitation.class.name.underscore
       ), status: :unprocessable_entity
     elsif @user.save
       send_notification_email

--- a/app/controllers/v1/user_controller.rb
+++ b/app/controllers/v1/user_controller.rb
@@ -13,7 +13,7 @@ class V1::UserController < ApplicationController
       organization_ids: extract_ids_from_params(:organization_ids)
     ))
 
-    user_invitation = [UserInvitation.find_by(email: user_params[:email]), InventoryInvitation.find_by(email: user_params[:email])].find{|invitation| !invitation.nil?}
+    user_invitation = [UserInvitation, InventoryInvitation].map{|i| i.find_by(email: user_params[:email])}.compact.first
     if user_invitation.present?
       @user.errors.add(:base, "It seems you have already been invited. Please continue your registration here.")
       render json: @user.errors.to_h.merge(

--- a/app/views/v1/invitations/show.json.jbuilder
+++ b/app/views/v1/invitations/show.json.jbuilder
@@ -1,2 +1,3 @@
 json.partial! 'v1/shared/user', user: user
-json.assessment_id assessment_id 
+json.assessment_id assessment_id if defined? assessment_id
+json.inventory_id inventory_id if defined? inventory_id

--- a/spec/controllers/v1/invitations_controller_spec.rb
+++ b/spec/controllers/v1/invitations_controller_spec.rb
@@ -24,19 +24,41 @@ describe V1::InvitationsController do
     end
 
     describe '#show' do
-      it 'shows the invitation by the token' do
-        get :show, token: 'expected_token'
-        assert_response :success
+      context 'assessment' do
+        it 'shows the invitation by the token' do
+          get :show, token: 'expected_token'
+          assert_response :success
 
-        expect(json["token"]).to be_nil
-        expect(json["email"]).to eq(@user.email)
+          expect(json["token"]).to be_nil
+          expect(json["email"]).to eq(@user.email)
+        end
+
+        it 'returns an assessment_id' do
+          get :show, token: 'expected_token'
+          assert_response :success
+
+          expect(json["assessment_id"]).to eq(assessment.id)
+        end
       end
 
-      it 'returns an assessment_id' do
-        get :show, token: 'expected_token'
-        assert_response :success
+      context 'inventory' do
+        let!(:user) { FactoryGirl.create(:user) }
+        let!(:invitation) { FactoryGirl.create(:inventory_invitation, user: user, email: user.email) }
 
-        expect(json["assessment_id"]).to eq(assessment.id)
+        before(:each) do
+          get :show, token: invitation.token
+        end
+
+        it{ expect(response).to have_http_status(:success) }
+
+        it 'shows the invitation by the token' do
+          expect(json["token"]).to be_nil
+          expect(json["email"]).to eq(invitation.email)
+        end
+
+        it 'returns an inventory_id' do
+          expect(json["inventory_id"]).to eq(invitation.inventory.id)
+        end
       end
     end
 

--- a/spec/controllers/v1/user_controller_spec.rb
+++ b/spec/controllers/v1/user_controller_spec.rb
@@ -205,6 +205,22 @@ describe V1::UserController do
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(json['invitation_token']).to eq(invitation.token)
+      expect(json['invitation_type']).to eq('user_invitation')
+    end 
+
+    it 'returns token to user invite when trying to signup with existing inventory invitation' do 
+      inventory = FactoryGirl.create(:inventory)
+      invitation = InventoryInvitation.create!(email: 'kim@gov.nk',
+                            inventory: inventory,
+                            first_name: 'Kim',
+                            last_name: 'Possible', 
+                            team_role: 'role;')
+
+      post_create_user(first_name: 'New')
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json['invitation_token']).to eq(invitation.token)
+      expect(json['invitation_type']).to eq('inventory_invitation')
     end 
   end
 

--- a/spec/controllers/v1/user_controller_spec.rb
+++ b/spec/controllers/v1/user_controller_spec.rb
@@ -205,7 +205,6 @@ describe V1::UserController do
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(json['invitation_token']).to eq(invitation.token)
-      expect(json['invitation_type']).to eq('user_invitation')
     end 
 
     it 'returns token to user invite when trying to signup with existing inventory invitation' do 
@@ -220,7 +219,6 @@ describe V1::UserController do
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(json['invitation_token']).to eq(invitation.token)
-      expect(json['invitation_type']).to eq('inventory_invitation')
     end 
   end
 

--- a/spec/controllers/v1/user_controller_spec.rb
+++ b/spec/controllers/v1/user_controller_spec.rb
@@ -192,10 +192,10 @@ describe V1::UserController do
       assert_response 422
     end
     
-    it 'redeems an already existing invite and updates the user' do 
+    it 'returns token to user invite when trying to signup with existing assessment invitation' do 
       create_magic_assessments
       user.update(email: 'kim@gov.nk')
-      UserInvitation.create!(email: 'kim@gov.nk',
+      invitation = UserInvitation.create!(email: 'kim@gov.nk',
                             assessment: @assessment_with_participants,
                             first_name: 'Kim',
                             last_name: 'Possible', 
@@ -203,10 +203,8 @@ describe V1::UserController do
 
       post_create_user(first_name: 'New')
 
-      assert_response :success
-      expect(UserInvitation.find_by(email: 'kim@gov.nk')).to eq(nil)
-      user = User.find_by_email('kim@gov.nk')
-      expect(user[:first_name]).to eq('New')
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json['invitation_token']).to eq(invitation.token)
     end 
   end
 


### PR DESCRIPTION
Fixes the following scenarios:

> When a **visitor** is trying to signup and there is an **invite to an assessment** in place with that same email address, the user should be redirected to complete the signup process through the assessment invite.

> When a **visitor** is trying to signup and there is an **invite to an inventory** in place with that same email address, the user should be redirected to complete the signup process through the inventory invite.