### PR TITLE
Update annotate gem and automatic annotate on dev database migrations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,10 +49,10 @@ GEM
       railties (>= 3.1)
       sprockets (~> 2)
       tilt
-    annotate (2.6.10)
-      activerecord (>= 3.2, <= 4.3)
+    annotate (2.7.0)
+      activerecord (>= 3.2, < 6.0)
       rake (~> 10.4)
-    arel (6.0.0)
+    arel (6.0.3)
     authority (3.0.0)
       activesupport (>= 3.0.0)
       rake (>= 0.8.7)

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,45 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  task :set_annotation_options do
+    Annotate.set_defaults(
+      'routes'                  => 'false',
+      'position_in_routes'      => 'before',
+      'position_in_class'       => 'before',
+      'position_in_test'        => 'before',
+      'position_in_fixture'     => 'before',
+      'position_in_factory'     => 'before',
+      'position_in_serializer'  => 'before',
+      'show_foreign_keys'       => 'true',
+      'show_indexes'            => 'true',
+      'simple_indexes'          => 'false',
+      'model_dir'               => 'app/models',
+      'root_dir'                => '',
+      'include_version'         => 'false',
+      'require'                 => '',
+      'exclude_tests'           => 'false',
+      'exclude_fixtures'        => 'false',
+      'exclude_factories'       => 'false',
+      'exclude_serializers'     => 'false',
+      'exclude_scaffolds'       => 'false',
+      'exclude_controllers'     => 'false',
+      'exclude_helpers'         => 'false',
+      'ignore_model_sub_dir'    => 'false',
+      'ignore_columns'          => nil,
+      'ignore_unknown_models'   => 'false',
+      'hide_limit_column_types' => 'integer,boolean',
+      'skip_on_db_migrate'      => 'false',
+      'format_bare'             => 'true',
+      'format_rdoc'             => 'false',
+      'format_markdown'         => 'false',
+      'sort'                    => 'false',
+      'force'                   => 'false',
+      'trace'                   => 'false',
+      'wrapper_open'            => nil,
+      'wrapper_close'           => nil,
+    )
+  end
+
+  Annotate.load_tasks
+end


### PR DESCRIPTION
What is this?
* `annotate` updated to it's latest version **2.7.0**
* `annotate` will now run automatically upon `rake db:migrate`

I also want us to use the same annotate version across the team and prevent this:

![](https://cloud.githubusercontent.com/assets/219289/14676978/4805671e-06d5-11e6-9f53-2f6b20f689d6.png)