### PR TITLE
Closes #127, Closes #184: inventory report and share by link

### DIFF
--- a/app/assets/javascripts/client/forms/fakeCheckbox.js
+++ b/app/assets/javascripts/client/forms/fakeCheckbox.js
@@ -7,7 +7,8 @@
     return {
       restrict: 'E',
       scope: {
-        model: '='
+        model: '=',
+        required: '='
       },
       replace: true,
       templateUrl: 'client/forms/fake_checkbox.html'

--- a/app/assets/javascripts/client/forms/fake_checkbox.html
+++ b/app/assets/javascripts/client/forms/fake_checkbox.html
@@ -1,4 +1,4 @@
 <div class='fake-checkbox'>
-  <input type='checkbox' ng-model='model'>
+  <input type='checkbox' ng-model='model' ng-required='required'>
   <span><i class='fa fa-check'></i></span>
 </div>

--- a/app/assets/javascripts/client/interceptors/UserAuthRedirector.js
+++ b/app/assets/javascripts/client/interceptors/UserAuthRedirector.js
@@ -1,4 +1,4 @@
-/*PDRClient.factory('UserAuthRedirector',[
+PDRClient.factory('UserAuthRedirector',[
     '$q', '$location', '$rootScope',
     function($q, $location, $rootScope){
       var sessionRecoverer = {
@@ -16,4 +16,3 @@
 PDRClient.config(['$httpProvider',function($httpProvider) {
   $httpProvider.interceptors.push('UserAuthRedirector');
 }]);
-*/

--- a/app/assets/javascripts/client/interceptors/UserAuthRedirector.js
+++ b/app/assets/javascripts/client/interceptors/UserAuthRedirector.js
@@ -1,4 +1,4 @@
-PDRClient.factory('UserAuthRedirector',[
+/*PDRClient.factory('UserAuthRedirector',[
     '$q', '$location', '$rootScope',
     function($q, $location, $rootScope){
       var sessionRecoverer = {
@@ -16,3 +16,4 @@ PDRClient.factory('UserAuthRedirector',[
 PDRClient.config(['$httpProvider',function($httpProvider) {
   $httpProvider.interceptors.push('UserAuthRedirector');
 }]);
+*/

--- a/app/assets/javascripts/client/inventories/AnalysisModalCtrl.js
+++ b/app/assets/javascripts/client/inventories/AnalysisModalCtrl.js
@@ -7,20 +7,29 @@
   AnalysisModalCtrl.$inject = [
     '$scope',
     'Analysis',
-    'Inventory'
+    'Inventory',
+    '$state'
   ];
 
-  function AnalysisModalCtrl($scope, Analysis, Inventory) {
+  function AnalysisModalCtrl($scope, Analysis, Inventory, $state) {
     var vm = this;
     vm.analysis = {};
     vm.alerts = [];
     vm.preSelectedInventory = $scope.inventory;
+    if(vm.preSelectedInventory) {
+      vm.analysis.inventory_id = vm.preSelectedInventory.id;
+    }
 
     vm.inventories = [];
     vm.hasFetchedInventories = false;
 
     vm.closeModal = function() {
       $scope.$emit('close-analysis-modal');
+    };
+
+    vm.gotoAnalyses = function() {
+      vm.closeModal();
+      $state.go('analyses');
     };
 
     vm.updateData = function () {
@@ -31,8 +40,8 @@
       return Inventory.query().$promise.then(function (response) {
         vm.inventories = response;
 
-        // ensure a district is always selected
-        if (_.any(vm.inventories)) {
+        // ensure an inventory is always selected unless it was pre-selected
+        if(!vm.analysis.inventory_id) {
           vm.analysis.inventory_id = vm.inventories[0].id;
         }
 
@@ -55,7 +64,6 @@
     vm.hasNoInventories = function () {
       return vm.hasFetchedInventories && _.isEmpty(vm.inventories);
     }
-
     vm.save = function () {
       Analysis.create(null, vm.analysis)
           .$promise

--- a/app/assets/javascripts/client/inventories/AnalysisModalCtrl.js
+++ b/app/assets/javascripts/client/inventories/AnalysisModalCtrl.js
@@ -41,7 +41,7 @@
         vm.inventories = response;
 
         // ensure an inventory is always selected unless it was pre-selected
-        if(!vm.analysis.inventory_id) {
+        if(!vm.analysis.inventory_id && vm.inventories.length > 0 ) {
           vm.analysis.inventory_id = vm.inventories[0].id;
         }
 

--- a/app/assets/javascripts/client/inventories/AnalysisModalCtrl.js
+++ b/app/assets/javascripts/client/inventories/AnalysisModalCtrl.js
@@ -14,6 +14,7 @@
     var vm = this;
     vm.analysis = {};
     vm.alerts = [];
+    vm.preSelectedInventory = $scope.inventory;
 
     vm.inventories = [];
     vm.hasFetchedInventories = false;

--- a/app/assets/javascripts/client/inventories/Inventory.js
+++ b/app/assets/javascripts/client/inventories/Inventory.js
@@ -32,7 +32,7 @@
         }
       },
       'saveResponse': {
-        method: 'PATCH',
+        method: 'POST',
         url: UrlService.url('inventories/:inventory_id/save_response'),
         params: {
           inventory_id: '@inventory_id'

--- a/app/assets/javascripts/client/inventories/InventoryDataEntriesCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryDataEntriesCtrl.js
@@ -14,6 +14,7 @@
   function InventoryDataEntriesCtrl($scope, $q, DataEntry, DTOptionsBuilder, DTColumnBuilder) {
     var vm = this;
     vm.inventory = $scope.inventory;
+    vm.readOnly = $scope.readOnly;
     var options = DTOptionsBuilder.fromFnPromise(function() {
       var deferred = $q.defer();
       DataEntry.get({inventory_id: vm.inventory.id}).$promise.then(function(results) {

--- a/app/assets/javascripts/client/inventories/InventoryDataEntriesCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryDataEntriesCtrl.js
@@ -15,9 +15,12 @@
     var vm = this;
     vm.inventory = $scope.inventory;
     vm.readOnly = $scope.readOnly;
+    vm.shared = $scope.shared;
+
+    var inventoryId = vm.shared ? vm.inventory.share_token : vm.inventory.id;
     var options = DTOptionsBuilder.fromFnPromise(function() {
       var deferred = $q.defer();
-      DataEntry.get({inventory_id: vm.inventory.id}).$promise.then(function(results) {
+      DataEntry.get({inventory_id: inventoryId}).$promise.then(function(results) {
         deferred.resolve(results.data_entries);
       }, deferred.reject);
       return deferred.promise;

--- a/app/assets/javascripts/client/inventories/InventoryProductEntriesCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryProductEntriesCtrl.js
@@ -14,6 +14,7 @@
   function InventoryProductEntriesCtrl($scope, $q, ProductEntry, DTOptionsBuilder, DTColumnBuilder) {
     var vm = this;
     vm.inventory = $scope.inventory;
+    vm.readOnly = $scope.readOnly;
     var options = DTOptionsBuilder.fromFnPromise(function() {
       var deferred = $q.defer();
       ProductEntry.get({inventory_id: vm.inventory.id}).$promise.then(function(results) {

--- a/app/assets/javascripts/client/inventories/InventoryProductEntriesCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryProductEntriesCtrl.js
@@ -15,9 +15,12 @@
     var vm = this;
     vm.inventory = $scope.inventory;
     vm.readOnly = $scope.readOnly;
+    vm.shared = $scope.shared;
+    var inventoryId = vm.shared ? vm.inventory.share_token : vm.inventory.id;
+
     var options = DTOptionsBuilder.fromFnPromise(function() {
       var deferred = $q.defer();
-      ProductEntry.get({inventory_id: vm.inventory.id}).$promise.then(function(results) {
+      ProductEntry.get({inventory_id: inventoryId}).$promise.then(function(results) {
         deferred.resolve(results.product_entries);
       }, deferred.reject);
       return deferred.promise;

--- a/app/assets/javascripts/client/inventories/InventoryReportCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportCtrl.js
@@ -1,0 +1,14 @@
+(function() {
+  'use strict';
+  angular.module('PDRClient')
+      .controller('InventoryReportCtrl', InventoryReportCtrl);
+
+  InventoryReportCtrl.$inject = [
+    'inventory'
+  ];
+
+  function InventoryReportCtrl(inventory) {
+    var vm = this;
+    vm.inventory = inventory;
+  }
+})();

--- a/app/assets/javascripts/client/inventories/InventoryReportCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportCtrl.js
@@ -4,11 +4,13 @@
       .controller('InventoryReportCtrl', InventoryReportCtrl);
 
   InventoryReportCtrl.$inject = [
+    '$stateParams',
     'inventory'
   ];
 
-  function InventoryReportCtrl(inventory) {
+  function InventoryReportCtrl($stateParams, inventory) {
     var vm = this;
     vm.inventory = inventory;
+    vm.shared = $stateParams.shared || false;
   }
 })();

--- a/app/assets/javascripts/client/inventories/InventoryReportDownloadCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportDownloadCtrl.js
@@ -1,0 +1,30 @@
+(function() {
+  'use strict';
+  angular.module('PDRClient').controller('InventoryReportDownloadCtrl', InventoryReportDownloadCtrl);
+
+  InventoryReportDownloadCtrl.$inject = ['$scope', 'UrlService'];
+
+  function InventoryReportDownloadCtrl($scope, UrlService) {
+    var vm = this;
+    vm.inventory = $scope.inventory;
+    vm.download = function() {
+      if(vm.downloadOptions.productEntries) {
+        var link = angular.element('<a/>');
+        link.attr({
+          href: UrlService.url('/inventories/' + vm.inventory.id + '/product_entries.csv'),
+          target: '_blank',
+          download: 'inventory_' + vm.inventory.id + '_product_entries_report.csv'
+        })[0].click();
+      }
+      if(vm.downloadOptions.dataEntries) {
+        var link = angular.element('<a/>');
+        link.attr({
+          href: UrlService.url('/inventories/' + vm.inventory.id + '/data_entries.csv'),
+          target: '_blank',
+          download: 'inventory_' + vm.inventory.id + '_data_entries_report.csv'
+        })[0].click();
+      }
+      $scope.$emit('inventory-report-downloaded');
+    };
+  }
+})();

--- a/app/assets/javascripts/client/inventories/InventoryReportDownloadCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportDownloadCtrl.js
@@ -7,25 +7,22 @@
   function InventoryReportDownloadCtrl($scope, UrlService) {
     var vm = this;
     vm.inventory = $scope.inventory;
-    console.log("Report sidebar Inventory ", vm.inventory);
-    vm.download = function() {
-      if(vm.downloadOptions.productEntries) {
+    vm.download = function () {
+      var buildLink = function (prefix) {
         var link = angular.element('<a/>');
         link.attr({
-          href: UrlService.url('/inventories/' + vm.inventory.id + '/product_entries.csv'),
+          href: UrlService.url('/inventories'/ + vm.inventory.id + '/' + prefix + '.csv'),
           target: '_blank',
-          download: 'inventory_' + vm.inventory.id + '_product_entries_report.csv'
+          download: 'inventory_' + vm.inventory.id + '_' + prefix + '_report.csv'
         })[0].click();
       }
-      if(vm.downloadOptions.dataEntries) {
-        var link = angular.element('<a/>');
-        link.attr({
-          href: UrlService.url('/inventories/' + vm.inventory.id + '/data_entries.csv'),
-          target: '_blank',
-          download: 'inventory_' + vm.inventory.id + '_data_entries_report.csv'
-        })[0].click();
+      if (vm.downloadOptions.productEntries) {
+        buildLink('product_entries');
+      }
+      if (vm.downloadOptions.dataEntries) {
+        buildLink('data_entries');
       }
       $scope.$emit('inventory-report-downloaded');
-    };
+    }
   }
 })();

--- a/app/assets/javascripts/client/inventories/InventoryReportDownloadCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportDownloadCtrl.js
@@ -7,6 +7,7 @@
   function InventoryReportDownloadCtrl($scope, UrlService) {
     var vm = this;
     vm.inventory = $scope.inventory;
+    console.log("Report sidebar Inventory ", vm.inventory);
     vm.download = function() {
       if(vm.downloadOptions.productEntries) {
         var link = angular.element('<a/>');

--- a/app/assets/javascripts/client/inventories/InventoryReportDownloadCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportDownloadCtrl.js
@@ -10,8 +10,9 @@
     vm.download = function () {
       var buildLink = function (prefix) {
         var link = angular.element('<a/>');
+        var downloadUrl = UrlService.url('/inventories/' + vm.inventory.id + '/' + prefix + '.csv')
         link.attr({
-          href: UrlService.url('/inventories'/ + vm.inventory.id + '/' + prefix + '.csv'),
+          href: downloadUrl,
           target: '_blank',
           download: 'inventory_' + vm.inventory.id + '_' + prefix + '_report.csv'
         })[0].click();

--- a/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
@@ -1,0 +1,29 @@
+(function() {
+  'use strict';
+  angular.module('PDRClient')
+      .controller('InventoryReportSidebarCtrl', InventoryReportSidebarCtrl);
+
+  InventoryReportSidebarCtrl.$inject = [
+    '$scope',
+    '$modal',
+    'inventory'
+  ];
+
+  function InventoryReportSidebarCtrl($scope, $modal, inventory) {
+    var vm = this;
+    $scope.inventory = inventory;
+    vm.downloadReport = function() {
+      vm.downloadModal = $modal.open({
+        templateUrl: 'client/inventories/inventory_report_download_modal.html',
+        scope: $scope
+      });
+    };
+
+    vm.closeDownloadReportModal = function() {
+      vm.downloadModal.dismiss();
+    };
+    $scope.$on('inventory-report-downloaded', function() {
+      vm.closeDownloadReportModal();
+    });
+  }
+})();

--- a/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
@@ -20,8 +20,8 @@
     vm.hideAnalysisAccess = inventory.analysis_count == 0 && user.role == 'participant';
     vm.gotoAnalysis = function() {
       if(vm.inventory.analysis_count == 0) {
-        vm.modalInstance = $modal.open({
-          template: '<analysis-modal></analysis-modal>',
+        vm.analysisModal = $modal.open({
+          template: '<analysis-modal inventory="inventory"></analysis-modal>',
           scope: $scope
         });
       }
@@ -38,6 +38,9 @@
     };
     $scope.$on('inventory-report-downloaded', function() {
       vm.closeDownloadReportModal();
+    });
+    $scope.$on('close-analysis-modal', function() {
+      vm.analysisModal.dismiss();
     });
   }
 })();

--- a/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
@@ -8,22 +8,32 @@
     '$modal',
     'inventory',
     '$stateParams',
-    'SessionService'
+    'SessionService',
+    '$state'
   ];
 
-  function InventoryReportSidebarCtrl($scope, $modal, inventory, $stateParams, SessionService) {
+  function InventoryReportSidebarCtrl($scope, $modal, inventory, $stateParams, SessionService, $state) {
     var vm = this;
     $scope.inventory = inventory;
     vm.inventory = $scope.inventory;
     vm.shared = $stateParams.shared || false;
     var user = SessionService.getCurrentUser();
     vm.hideAnalysisAccess = inventory.analysis_count == 0 && user.role == 'participant';
+    vm.creatingAnalysis = vm.inventory.analysis_count == 0 && vm.inventory.is_facilitator;
+    vm.createAnalysis = function() {
+      vm.analysisModal = $modal.open({
+        template: '<analysis-modal inventory="inventory"></analysis-modal>',
+        scope: $scope
+      });
+    };
     vm.gotoAnalysis = function() {
-      if(vm.inventory.analysis_count == 0) {
-        vm.analysisModal = $modal.open({
-          template: '<analysis-modal inventory="inventory"></analysis-modal>',
-          scope: $scope
+      if(vm.inventory.analysis_count == 1) {
+        var analysisState = !vm.inventory.analysis.assigned_at ? 'analysis_assign' :'analysis_dashboard' ;
+        $state.go(analysisState, {
+          id: vm.inventory.analysis.id
         });
+      } else {
+        $state.go('analyses');
       }
     };
     vm.downloadReport = function() {

--- a/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
@@ -18,8 +18,8 @@
     vm.inventory = $scope.inventory;
     vm.shared = $stateParams.shared || false;
     var user = SessionService.getCurrentUser();
-    vm.hideAnalysisAccess = inventory.analysis_count == 0 && user.role == 'participant';
-    vm.creatingAnalysis = vm.inventory.analysis_count == 0 && vm.inventory.is_facilitator;
+    vm.hideAnalysisAccess = inventory.analysis_count === 0 && !vm.inventory.is_facilitator;
+    vm.creatingAnalysis = vm.inventory.analysis_count === 0 && vm.inventory.is_facilitator;
     vm.createAnalysis = function() {
       vm.analysisModal = $modal.open({
         template: '<analysis-modal inventory="inventory"></analysis-modal>',

--- a/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
@@ -7,14 +7,25 @@
     '$scope',
     '$modal',
     'inventory',
-    '$stateParams'
+    '$stateParams',
+    'SessionService'
   ];
 
-  function InventoryReportSidebarCtrl($scope, $modal, inventory, $stateParams) {
+  function InventoryReportSidebarCtrl($scope, $modal, inventory, $stateParams, SessionService) {
     var vm = this;
     $scope.inventory = inventory;
     vm.inventory = $scope.inventory;
     vm.shared = $stateParams.shared || false;
+    var user = SessionService.getCurrentUser();
+    vm.hideAnalysisAccess = inventory.analysis_count == 0 && user.role == 'participant';
+    vm.gotoAnalysis = function() {
+      if(vm.inventory.analysis_count == 0) {
+        vm.modalInstance = $modal.open({
+          template: '<analysis-modal></analysis-modal>',
+          scope: $scope
+        });
+      }
+    };
     vm.downloadReport = function() {
       vm.downloadModal = $modal.open({
         templateUrl: 'client/inventories/inventory_report_download_modal.html',

--- a/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
@@ -30,7 +30,7 @@
       if(vm.inventory.analysis_count == 1) {
         var analysisState = !vm.inventory.analysis.assigned_at ? 'analysis_assign' :'analysis_dashboard' ;
         $state.go(analysisState, {
-          id: vm.inventory.analysis.id
+          analysis_id: vm.inventory.analysis.id
         });
       } else {
         $state.go('analyses');

--- a/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
@@ -6,12 +6,15 @@
   InventoryReportSidebarCtrl.$inject = [
     '$scope',
     '$modal',
-    'inventory'
+    'inventory',
+    '$stateParams'
   ];
 
-  function InventoryReportSidebarCtrl($scope, $modal, inventory) {
+  function InventoryReportSidebarCtrl($scope, $modal, inventory, $stateParams) {
     var vm = this;
     $scope.inventory = inventory;
+    vm.inventory = $scope.inventory;
+    vm.shared = $stateParams.shared || false;
     vm.downloadReport = function() {
       vm.downloadModal = $modal.open({
         templateUrl: 'client/inventories/inventory_report_download_modal.html',

--- a/app/assets/javascripts/client/inventories/InventoryScheduleCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryScheduleCtrl.js
@@ -11,7 +11,7 @@
 
   function InventoryScheduleCtrl($scope, $modal) {
     var vm = this;
-
+    vm.onlySchedule = $scope.onlySchedule;
     vm.displayLearningQuestions = function () {
       vm.modal = $modal.open({
         template: '<learning-question-modal context="inventory" reminder="false" />',

--- a/app/assets/javascripts/client/inventories/analysisModal.js
+++ b/app/assets/javascripts/client/inventories/analysisModal.js
@@ -9,7 +9,9 @@
       restrict: 'E',
       replace: true,
       transclude: true,
-      scope: {},
+      scope: {
+        inventory:'='
+      },
       templateUrl: 'client/inventories/analysis_modal.html',
       controller: 'AnalysisModalCtrl',
       controllerAs: 'analysisModal',

--- a/app/assets/javascripts/client/inventories/analysis_modal.html
+++ b/app/assets/javascripts/client/inventories/analysis_modal.html
@@ -60,12 +60,13 @@
           <div class='form-group'>
             <label for='analysis-inventory-id' class='required'>Inventory</label>
             <select 
+              ng-disabled="analysisModal.preSelectedInventory"
                 class='form-control'
                 required
                 ng-model='analysisModal.analysis.inventory_id'
                 ng-options='inventory.id as inventory.name for inventory in analysisModal.inventories'
                 id='analysis-inventory-id'></select>
-          </div>
+			</div>
         </div>
       </div>
 

--- a/app/assets/javascripts/client/inventories/analysis_modal.html
+++ b/app/assets/javascripts/client/inventories/analysis_modal.html
@@ -1,28 +1,27 @@
 <div class='container modal-form'>
   <h1>Create a New Analysis</h1>
   <button class='btn btn-link close-modal' ng-click='analysisModal.closeModal()'>&times;</button>
-
   <hr>
-
-  <div ng-show='analysisModal.hasNoInventories()'>
+  <div ng-if='analysisModal.hasNoInventories()'>
     <div class='row'>
       <div class='col-sm-12'>
         <div class='notice'>
           <h2>You need to have an Inventory to create an Analysis</h2>
-          <p>The Data & Tech Analysis needs to be linked to a Data &amp; Tech Inventory to be most effective. If you've already built an inventory, check to make sure you are a facilitator of that inventory in order to create an analysis. You can also start a new inventory by clicking below.</p>
+          <p>The Data &amp; Tech Analysis needs to be linked to a Data &amp; Tech Inventory to be most effective. If you've already built an inventory, check to make sure you are a facilitator of that inventory in order to create an analysis. You can also start a new inventory by clicking below.</p>
           <p><start-inventory></start-inventory></p>
         </div>
       </div>
     </div>
-
     <hr>
-   </div>
+  </div>
 
   <div ng-show='analysisModal.hasInventories()'>
     <alert ng-repeat="alert in analysisModal.alerts" type="{{alert.type}}" close="analysisModal.closeAlert($index)">{{alert.msg}}</alert>
+  </div>
+  <div ng-if='analysisModal.hasInventories()'>
     <div class='row'>
       <div class='col-sm-12'>
-        <p>Facilitate the Data &amp; Tech Analysis process for your district by creating a new analysis and selecting an inventory to connect to it. Click here to view current analyses for your district or to participate in an existing analysis.</p>
+        <p>Facilitate the Data &amp; Tech Analysis process for your district by creating a new analysis and selecting an inventory to connect to it. Click <a href="#/analyses" ng-click="analysisModal.gotoAnalyses()">here</a> to view current analyses for your district or to participate in an existing analysis.</p>
       </div>
     </div>
 

--- a/app/assets/javascripts/client/inventories/inventoryDataEntries.js
+++ b/app/assets/javascripts/client/inventories/inventoryDataEntries.js
@@ -7,7 +7,8 @@
     return {
       restrict: 'E',
       scope: {
-        inventory: '='
+        inventory: '=',
+        readOnly: '='
       },
       templateUrl: 'client/inventories/inventory_data_entries.html',
       controller: 'InventoryDataEntriesCtrl',

--- a/app/assets/javascripts/client/inventories/inventoryDataEntries.js
+++ b/app/assets/javascripts/client/inventories/inventoryDataEntries.js
@@ -8,7 +8,8 @@
       restrict: 'E',
       scope: {
         inventory: '=',
-        readOnly: '='
+        readOnly: '=',
+        shared: '='
       },
       templateUrl: 'client/inventories/inventory_data_entries.html',
       controller: 'InventoryDataEntriesCtrl',

--- a/app/assets/javascripts/client/inventories/inventoryProductEntries.js
+++ b/app/assets/javascripts/client/inventories/inventoryProductEntries.js
@@ -7,7 +7,8 @@
     return {
       restrict: 'E',
       scope: {
-        inventory: '='
+        inventory: '=',
+        readOnly: '='
       },
       templateUrl: 'client/inventories/inventory_product_entries.html',
       controller: 'InventoryProductEntriesCtrl',

--- a/app/assets/javascripts/client/inventories/inventoryProductEntries.js
+++ b/app/assets/javascripts/client/inventories/inventoryProductEntries.js
@@ -8,7 +8,8 @@
       restrict: 'E',
       scope: {
         inventory: '=',
-        readOnly: '='
+        readOnly: '=',
+        shared: '='
       },
       templateUrl: 'client/inventories/inventory_product_entries.html',
       controller: 'InventoryProductEntriesCtrl',

--- a/app/assets/javascripts/client/inventories/inventoryReportDownload.js
+++ b/app/assets/javascripts/client/inventories/inventoryReportDownload.js
@@ -1,0 +1,18 @@
+(function () {
+  'use strict';
+  angular.module('PDRClient')
+      .directive('inventoryReportDownload', inventoryReportDownload);
+
+  function inventoryReportDownload() {
+    return {
+      restrict: 'E',
+      scope: {
+        inventory: '='
+      },
+      templateUrl: 'client/inventories/inventory_report_download.html',
+      controller: 'InventoryReportDownloadCtrl',
+      controllerAs: 'inventoryReportDownload',
+      replace: true
+    }
+  }
+})();

--- a/app/assets/javascripts/client/inventories/inventorySchedule.js
+++ b/app/assets/javascripts/client/inventories/inventorySchedule.js
@@ -10,7 +10,8 @@
       replace: true,
       transclude: true,
       scope: {
-        inventory: '='
+        inventory: '=',
+        onlySchedule: '='
       },
       templateUrl: 'client/inventories/inventory_schedule.html',      
       controller: 'InventoryScheduleCtrl',

--- a/app/assets/javascripts/client/inventories/inventory_data_entries.html
+++ b/app/assets/javascripts/client/inventories/inventory_data_entries.html
@@ -1,7 +1,7 @@
 <div class="inventory-items-list">
   <div class="header">
     <h4 class="pull-left">Data</h4>
-     <inventory-data-entry inventory="inventoryDataEntries.inventory"></inventory-data-entry>
+     <inventory-data-entry inventory="inventoryDataEntries.inventory" ng-hide="inventoryDataEntries.readOnly"></inventory-data-entry>
   </div>
   <div class="row">
     <div class="list col-md-12 table-responsive">

--- a/app/assets/javascripts/client/inventories/inventory_data_entries.html
+++ b/app/assets/javascripts/client/inventories/inventory_data_entries.html
@@ -1,7 +1,7 @@
 <div class="inventory-items-list">
   <div class="header">
     <h4 class="pull-left">Data</h4>
-     <inventory-data-entry inventory="inventoryDataEntries.inventory" ng-hide="inventoryDataEntries.readOnly"></inventory-data-entry>
+     <inventory-data-entry inventory="inventoryDataEntries.inventory" ng-if="!inventoryDataEntries.readOnly"></inventory-data-entry>
   </div>
   <div class="row">
     <div class="list col-md-12 table-responsive">

--- a/app/assets/javascripts/client/inventories/inventory_product_entries.html
+++ b/app/assets/javascripts/client/inventories/inventory_product_entries.html
@@ -1,7 +1,7 @@
 <div class="inventory-items-list">
   <div class="header">
     <h4 class="pull-left">Product</h4>
-     <product-entry inventory="inventoryProductEntries.inventory"></product-entry>
+     <product-entry inventory="inventoryProductEntries.inventory" ng-hide="readOnly"></product-entry>
   </div>
   <div class="row">
     <div class="list col-md-12 table-responsive">

--- a/app/assets/javascripts/client/inventories/inventory_product_entries.html
+++ b/app/assets/javascripts/client/inventories/inventory_product_entries.html
@@ -1,7 +1,7 @@
 <div class="inventory-items-list">
   <div class="header">
     <h4 class="pull-left">Product</h4>
-     <product-entry inventory="inventoryProductEntries.inventory" ng-hide="readOnly"></product-entry>
+     <product-entry inventory="inventoryProductEntries.inventory" ng-if="!inventoryProductEntries.readOnly"></product-entry>
   </div>
   <div class="row">
     <div class="list col-md-12 table-responsive">

--- a/app/assets/javascripts/client/inventories/inventory_report.html
+++ b/app/assets/javascripts/client/inventories/inventory_report.html
@@ -1,0 +1,11 @@
+<div class="row secondary user-header">
+  <div class="col-md-12">
+    <h1>{{inventoryReport.inventory.name}}</h1>
+      <p class="byline">Organized by: {{inventoryReport.inventory.facilitator.full_name}} on {{inventoryReport.inventory.created_at | amDateFormat:'MMMM Do, YYYY'}}</p>
+  </div>
+</div>
+<div class="row">
+  <inventory-product-entries read-only="true" inventory="inventoryReport.inventory"></inventory-product-entries>
+  <inventory-data-entries read-only="true" inventory="inventoryReport.inventory"></inventory-data-entries>
+</div>
+

--- a/app/assets/javascripts/client/inventories/inventory_report.html
+++ b/app/assets/javascripts/client/inventories/inventory_report.html
@@ -5,7 +5,7 @@
   </div>
 </div>
 <div class="row">
-  <inventory-product-entries read-only="true" inventory="inventoryReport.inventory"></inventory-product-entries>
-  <inventory-data-entries read-only="true" inventory="inventoryReport.inventory"></inventory-data-entries>
+  <inventory-product-entries read-only="true" shared="inventoryReport.shared" inventory="inventoryReport.inventory"></inventory-product-entries>
+  <inventory-data-entries read-only="true" shared="inventoryReport.shared" inventory="inventoryReport.inventory"></inventory-data-entries>
 </div>
 

--- a/app/assets/javascripts/client/inventories/inventory_report_download.html
+++ b/app/assets/javascripts/client/inventories/inventory_report_download.html
@@ -1,0 +1,28 @@
+<div>
+  <h4>Download Inventories</h4>
+  <form name="formDownload"  novalidate>
+    <div class="row">
+      <label>
+        <fake-checkbox ng-required='inventoryReportDownload.downloadOptions.productEntries || inventoryReportDownload.downloadOptions.dataEntries' model='inventoryReportDownload.downloadOptions.productEntries'></fake-checkbox>
+        Product Entries
+      </label>
+    </div>
+    <div class="row">
+      <label>
+        <fake-checkbox ng-required="inventoryReportDownload.downloadOptions.productEntries || inventoryReportDownload.downloadOptions.dataEntries" model='inventoryReportDownload.downloadOptions.dataEntries'></fake-checkbox>
+        Data Entries
+      </label>
+    </div>
+    <div class="form-group right">
+      <div
+        class="btn btn-primary pull-right"
+        ng-disabled="formDownload.$invalid"
+        ng-click="inventoryReportDownload.download()"
+        data-dismiss="modal">
+        Download
+      </div>
+    </div>
+    <div class='clearfix'>
+    </div>
+  </form>
+</div>

--- a/app/assets/javascripts/client/inventories/inventory_report_download_modal.html
+++ b/app/assets/javascripts/client/inventories/inventory_report_download_modal.html
@@ -1,0 +1,9 @@
+<div class="invite-user-modal">
+  <div class="modal-header">
+    <button ng-click="inventoryReportSidebar.closeDownloadReportModal()" type="button" class="close" aria-hidden="true">×</button>
+    <h3 class="modal-title">Download as a .CSV</h3>
+  </div>
+  <div class="modal-body">
+    <inventory-report-download inventory="inventory"></inventory-report-download>
+  </div>
+</div>

--- a/app/assets/javascripts/client/inventories/inventory_report_download_modal.html
+++ b/app/assets/javascripts/client/inventories/inventory_report_download_modal.html
@@ -4,6 +4,6 @@
     <h3 class="modal-title">Download as a .CSV</h3>
   </div>
   <div class="modal-body">
-    <inventory-report-download inventory="inventory"></inventory-report-download>
+    <inventory-report-download inventory="inventoryReportSidebar.inventory"></inventory-report-download>
   </div>
 </div>

--- a/app/assets/javascripts/client/inventories/inventory_routes.js
+++ b/app/assets/javascripts/client/inventories/inventory_routes.js
@@ -132,7 +132,37 @@
           controllerAs: 'inventoryReportSidebar',
           templateUrl: 'client/inventories/report_sidebar.html'
         }
+      },
+      params: {
+        shared: false
       }
-     });
+    }).state('inventories_shared_report', {
+      url: '/inventories/shared/:inventory_id/report',
+      views: {
+        '': {
+          resolve: {
+            inventory: ['Inventory', '$stateParams', function(Inventory, $stateParams) {
+              return Inventory.get({inventory_id: $stateParams.inventory_id}).$promise;
+            }]
+          },
+          controller: 'InventoryReportCtrl',
+          controllerAs: 'inventoryReport',
+          templateUrl: 'client/inventories/inventory_report.html',
+        },
+        'sidebar': {
+          resolve: {
+            inventory: ['Inventory', '$stateParams', function(Inventory, $stateParams) {
+              return Inventory.get({inventory_id: $stateParams.inventory_id}).$promise;
+            }]
+          },
+          controller: 'InventoryReportSidebarCtrl',
+          controllerAs: 'inventoryReportSidebar',
+          templateUrl: 'client/inventories/report_sidebar.html'
+        }
+      },
+      params: {
+        shared: true
+      }
+    });
   }
 })();

--- a/app/assets/javascripts/client/inventories/inventory_routes.js
+++ b/app/assets/javascripts/client/inventories/inventory_routes.js
@@ -108,6 +108,31 @@
           templateUrl: 'client/inventories/assign_analysis.html'
         }
       }
-    });
+    }).state('inventories_report', {
+      url: '/inventories/:inventory_id/report',
+      authenticate: true,
+      views: {
+        '': {
+          resolve: {
+            inventory: ['Inventory', '$stateParams', function(Inventory, $stateParams) {
+              return Inventory.get({inventory_id: $stateParams.inventory_id}).$promise;
+            }]
+          },
+          controller: 'InventoryReportCtrl',
+          controllerAs: 'inventoryReport',
+          templateUrl: 'client/inventories/inventory_report.html'
+        },
+        'sidebar': {
+          resolve: {
+            inventory: ['Inventory', '$stateParams', function(Inventory, $stateParams) {
+              return Inventory.get({inventory_id: $stateParams.inventory_id}).$promise;
+            }]
+          },
+          controller: 'InventoryReportSidebarCtrl',
+          controllerAs: 'inventoryReportSidebar',
+          templateUrl: 'client/inventories/report_sidebar.html'
+        }
+      }
+     });
   }
 })();

--- a/app/assets/javascripts/client/inventories/inventory_schedule.html
+++ b/app/assets/javascripts/client/inventories/inventory_schedule.html
@@ -21,7 +21,7 @@
   </div>
   <div class="inventory-schedule-buttons" ng-hide="inventorySchedule.onlySchedule">
     <button class="btn btn-block btn-tertiary separator-margin" ng-if="inventory.is_facilitator">Modify Schedule</button>
-    <button class="btn btn-block btn-tertiary separator-margin">Go To Report</button>
+    <button ui-sref="inventories_report({inventory_id: inventory.id})" class="btn btn-block btn-tertiary separator-margin">Go To Report</button>
     <button ng-click="inventorySchedule.displayLearningQuestions()"
             class="btn btn-block btn-secondary separator-margin">Add/Review Learning Questions</button>
   </div>

--- a/app/assets/javascripts/client/inventories/inventory_schedule.html
+++ b/app/assets/javascripts/client/inventories/inventory_schedule.html
@@ -19,8 +19,8 @@
       </div>
     </div>
   </div>
-  <div class="inventory-schedule-buttons">
-    <button class="btn btn-block btn-tertiary separator-margin"  ng-if="inventory.is_facilitator">Modify Schedule</button>
+  <div class="inventory-schedule-buttons" ng-hide="inventorySchedule.onlySchedule">
+    <button class="btn btn-block btn-tertiary separator-margin" ng-if="inventory.is_facilitator">Modify Schedule</button>
     <button class="btn btn-block btn-tertiary separator-margin">Go To Report</button>
     <button ng-click="inventorySchedule.displayLearningQuestions()"
             class="btn btn-block btn-secondary separator-margin">Add/Review Learning Questions</button>

--- a/app/assets/javascripts/client/inventories/report_sidebar.html
+++ b/app/assets/javascripts/client/inventories/report_sidebar.html
@@ -1,0 +1,13 @@
+<div class="sidebar inventory-edit-sidebar">
+  <ul>
+    <li>
+      <a class="btn btn-primary">Go to Analysis</a>
+    </li>
+    <li>
+      <a class="btn btn-secondary" ng-click="inventoryReportSidebar.downloadReport()">Download as .CSV</a>
+    </li>
+    <li>
+      <a class="btn btn-default">Dashboard</a>
+    </li>
+  </ul>
+</div>

--- a/app/assets/javascripts/client/inventories/report_sidebar.html
+++ b/app/assets/javascripts/client/inventories/report_sidebar.html
@@ -1,8 +1,8 @@
 <div class="sidebar inventory-edit-sidebar">
   <inventory-schedule only-schedule="true" inventory="inventoryReportSidebar.inventory"></inventory-schedule>
   <ul ng-hide="inventoryReportSidebar.shared">
-    <li>
-      <a class="btn btn-primary">Go to Analysis</a>
+    <li ng-hide="inventoryReportSidebar.hideAnalysisAccess">
+      <a class="btn btn-primary" ng-click="inventoryReportSidebar.gotoAnalysis()">Go to Analysis</a>
     </li>
     <li>
       <a class="btn btn-secondary" ng-click="inventoryReportSidebar.downloadReport()">Download as .CSV</a>

--- a/app/assets/javascripts/client/inventories/report_sidebar.html
+++ b/app/assets/javascripts/client/inventories/report_sidebar.html
@@ -1,8 +1,9 @@
 <div class="sidebar inventory-edit-sidebar">
   <inventory-schedule only-schedule="true" inventory="inventoryReportSidebar.inventory"></inventory-schedule>
   <ul ng-hide="inventoryReportSidebar.shared">
-    <li ng-hide="inventoryReportSidebar.hideAnalysisAccess">
-      <a class="btn btn-primary" ng-click="inventoryReportSidebar.gotoAnalysis()">Go to Analysis</a>
+    <li ng-if="!inventoryReportSidebar.hideAnalysisAccess">
+      <a ng-if="!inventoryReportSidebar.creatingAnalysis" class="btn btn-primary" ng-click="inventoryReportSidebar.gotoAnalysis()">Go to analysis</a>
+      <a ng-if="inventoryReportSidebar.creatingAnalysis" class="btn btn-primary" ng-click="inventoryReportSidebar.createAnalysis()">Create analysis</a>
     </li>
     <li>
       <a class="btn btn-secondary" ng-click="inventoryReportSidebar.downloadReport()">Download as .CSV</a>

--- a/app/assets/javascripts/client/inventories/report_sidebar.html
+++ b/app/assets/javascripts/client/inventories/report_sidebar.html
@@ -1,5 +1,6 @@
 <div class="sidebar inventory-edit-sidebar">
-  <ul>
+  <inventory-schedule only-schedule="true" inventory="inventoryReportSidebar.inventory"></inventory-schedule>
+  <ul ng-hide="inventoryReportSidebar.shared">
     <li>
       <a class="btn btn-primary">Go to Analysis</a>
     </li>

--- a/app/assets/javascripts/client/inventories/report_sidebar.html
+++ b/app/assets/javascripts/client/inventories/report_sidebar.html
@@ -9,7 +9,7 @@
       <a class="btn btn-secondary" ng-click="inventoryReportSidebar.downloadReport()">Download as .CSV</a>
     </li>
     <li>
-      <a class="btn btn-default">Dashboard</a>
+      <a ui-sref="inventory_dashboard({inventory_id: inventoryReportSidebar.inventory.id})" class="btn btn-default">Dashboard</a>
     </li>
   </ul>
 </div>

--- a/app/assets/stylesheets/pages/inventories.sass
+++ b/app/assets/stylesheets/pages/inventories.sass
@@ -21,9 +21,6 @@
       .btn
         width: 100% 
 
-    li:first-child
-      margin-top: 0em
-
     .btn-primary
       padding: 0.9em
 

--- a/app/authorizers/inventory_authorizer.rb
+++ b/app/authorizers/inventory_authorizer.rb
@@ -4,7 +4,7 @@ class InventoryAuthorizer < ApplicationAuthorizer
   end
 
   def updatable_by?(user)
-    resource.facilitator?(user: user)
+    resource.member?(user: user)
   end
 
   def readable_by?(user)

--- a/app/controllers/concerns/shared_inventory_fetch.rb
+++ b/app/controllers/concerns/shared_inventory_fetch.rb
@@ -6,11 +6,11 @@ module SharedInventoryFetch
     @inventory = Inventory.where('inventories.id = ? OR inventories.share_token = ?', id.to_i, id).first
     unless @inventory
       render nothing:true, status: :not_found
-      return
+      return nil
     end
     unless @inventory.share_token == id
       authenticate_user!
-      authorize_actions_for @inventory
+      authorize_action_for @inventory
     end
     @inventory
   end

--- a/app/controllers/concerns/shared_inventory_fetch.rb
+++ b/app/controllers/concerns/shared_inventory_fetch.rb
@@ -1,0 +1,17 @@
+module SharedInventoryFetch
+  extend ActiveSupport::Concern
+
+  def inventory
+    id = params[:inventory_id] || params[:id]
+    @inventory = Inventory.where('inventories.id = ? OR inventories.share_token = ?', id.to_i, id).first
+    unless @inventory
+      render nothing:true, status: :not_found
+      return
+    end
+    unless @inventory.share_token == id
+      authenticate_user!
+      authorize_actions_for @inventory
+    end
+    @inventory
+  end
+end

--- a/app/controllers/v1/data_entries_controller.rb
+++ b/app/controllers/v1/data_entries_controller.rb
@@ -1,5 +1,7 @@
 class V1::DataEntriesController < ApplicationController
-  before_action :authenticate_user!
+  include SharedInventoryFetch
+  before_action :authenticate_user!, except: :index
+  before_action :inventory, except: :index
 
   def index
     @data_entries = data_entries
@@ -39,11 +41,6 @@ class V1::DataEntriesController < ApplicationController
   end
 
   private
-  def inventory
-    current_user.inventories.find(params[:inventory_id])
-    #Inventory.find(params[:inventory_id])
-  end
-
   def data_entries
     inventory.data_entries
   end

--- a/app/controllers/v1/inventories_controller.rb
+++ b/app/controllers/v1/inventories_controller.rb
@@ -67,6 +67,8 @@ class V1::InventoriesController < ApplicationController
     end
   end
 
+  authority_actions mark_complete: :update
+
   def save_response
     member = inventory.members.where(user: current_user).first
     response = InventoryResponse.find_or_create_by(inventory_member: member)
@@ -80,12 +82,16 @@ class V1::InventoriesController < ApplicationController
     end
   end
 
+  authority_actions save_response: :update
+
   def participant_response
     member = inventory.members.where(user: current_user).first
     render json: {
         hasResponded: member.has_responded?
     }, status: :ok
   end
+
+  authority_actions participant_response: :create
 
   private
   def inventory_params

--- a/app/controllers/v1/inventories_controller.rb
+++ b/app/controllers/v1/inventories_controller.rb
@@ -8,7 +8,7 @@ class V1::InventoriesController < ApplicationController
 
   def show
     @inventory = inventory
-    @messages = messages
+    @messages = messages if @inventory
   end
 
   def create

--- a/app/controllers/v1/inventories_controller.rb
+++ b/app/controllers/v1/inventories_controller.rb
@@ -1,19 +1,23 @@
 class V1::InventoriesController < ApplicationController
 
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: :show
 
   def index
     @inventories = Inventory.where(district_id: current_user.districts)
   end
 
   def show
-    @inventory = Inventory.where(id: params[:id]).first
+    id = params[:id]
+    @inventory = Inventory.where('inventories.id = ? OR inventories.share_token = ?', id.to_i, id).first
     unless @inventory
       render nothing: true, status: :not_found
       return
     end
     @messages = messages
-    authorize_action_for @inventory
+    unless @inventory.share_token == id
+      authenticate_user!
+      authorize_action_for @inventory
+    end
   end
 
   def create

--- a/app/controllers/v1/inventories_controller.rb
+++ b/app/controllers/v1/inventories_controller.rb
@@ -1,5 +1,5 @@
 class V1::InventoriesController < ApplicationController
-
+  include SharedInventoryFetch
   before_action :authenticate_user!, except: :show
 
   def index
@@ -7,17 +7,8 @@ class V1::InventoriesController < ApplicationController
   end
 
   def show
-    id = params[:id]
-    @inventory = Inventory.where('inventories.id = ? OR inventories.share_token = ?', id.to_i, id).first
-    unless @inventory
-      render nothing: true, status: :not_found
-      return
-    end
+    @inventory = inventory
     @messages = messages
-    unless @inventory.share_token == id
-      authenticate_user!
-      authorize_action_for @inventory
-    end
   end
 
   def create
@@ -105,10 +96,6 @@ class V1::InventoriesController < ApplicationController
     render json: {
         errors: @inventory.errors,
     }, status: :bad_request
-  end
-
-  def inventory
-    Inventory.where(id: (params[:inventory_id] || params[:id])).first
   end
 
   def messages

--- a/app/controllers/v1/product_entries_controller.rb
+++ b/app/controllers/v1/product_entries_controller.rb
@@ -1,5 +1,7 @@
 class V1::ProductEntriesController < ApplicationController
-  before_action :authenticate_user!
+  include SharedInventoryFetch
+  before_action :authenticate_user!, except: :index
+  before_action :inventory, except: :index
 
   def index
     @product_entries = product_entries
@@ -39,10 +41,6 @@ class V1::ProductEntriesController < ApplicationController
   end
 
   private
-  def inventory
-    current_user.inventories.find(params[:inventory_id])
-  end
-
   def product_entries
     inventory.product_entries
   end

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -28,6 +28,7 @@ class Inventory < ActiveRecord::Base
   belongs_to :owner, class_name: 'User'
 
   has_many :analyses
+  before_save :ensure_share_token
 
   self.authorizer_name = 'InventoryAuthorizer'
 
@@ -101,5 +102,9 @@ class Inventory < ActiveRecord::Base
 
   def pending_requests?(user)
     access_requests.where(user: user).present?
+  end
+  
+  def ensure_share_token
+    self.share_token ||= SecureRandom.hex(32)
   end
 end

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -91,8 +91,8 @@ class Inventory < ActiveRecord::Base
     participants.count
   end
 
-  def analysis_count
-    Analysis.where(inventory_id: id).count
+  def current_analysis
+    analyses.last
   end
 
   private

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -91,6 +91,11 @@ class Inventory < ActiveRecord::Base
     participants.count
   end
 
+  def analysis_count
+    Analysis.where(inventory_id: id).count
+  end
+
+  private
   def add_facilitator_owner
     return unless owner
     facilitators.create(user: owner)

--- a/app/views/v1/inventories/_inventory.json.jbuilder
+++ b/app/views/v1/inventories/_inventory.json.jbuilder
@@ -27,3 +27,4 @@ json.messages @messages, :id, :category, :teaser, :sent_at do |message|
 end
 json.share_token inventory.share_token
 json.analysis_count inventory.analysis_count
+json.analysis inventory.analysis

--- a/app/views/v1/inventories/_inventory.json.jbuilder
+++ b/app/views/v1/inventories/_inventory.json.jbuilder
@@ -26,3 +26,4 @@ json.messages @messages, :id, :category, :teaser, :sent_at do |message|
   json.sent_at  message.sent_at
 end
 json.share_token inventory.share_token
+json.analysis_count inventory.analysis_count

--- a/app/views/v1/inventories/_inventory.json.jbuilder
+++ b/app/views/v1/inventories/_inventory.json.jbuilder
@@ -26,5 +26,5 @@ json.messages @messages, :id, :category, :teaser, :sent_at do |message|
   json.sent_at  message.sent_at
 end
 json.share_token inventory.share_token
-json.analysis_count inventory.analysis_count
-json.analysis inventory.analysis
+json.analysis_count inventory.analyses.count
+json.analysis inventory.current_analysis

--- a/app/views/v1/inventories/_inventory.json.jbuilder
+++ b/app/views/v1/inventories/_inventory.json.jbuilder
@@ -16,10 +16,9 @@ json.consensus do
 end
 json.percent_completed inventory.percent_completed
 json.completed_responses inventory.total_participant_responses
-json.has_access inventory.member?(user: current_user) || inventory.owner == current_user
+json.has_access inventory.member?(user: current_user) || inventory.owner == current_user if current_user
 json.participant_count inventory.participants.count
-json.message inventory.message || default_inventory_message
-
+json.message inventory.message || default_inventory_message if current_user
 json.messages @messages, :id, :category, :teaser, :sent_at do |message|
   json.id       message.id
   json.category message.category

--- a/app/views/v1/inventories/_inventory.json.jbuilder
+++ b/app/views/v1/inventories/_inventory.json.jbuilder
@@ -25,3 +25,4 @@ json.messages @messages, :id, :category, :teaser, :sent_at do |message|
   json.teaser   sanitize(message.teaser, tags: [])
   json.sent_at  message.sent_at
 end
+json.share_token inventory.share_token

--- a/db/migrate/20160420213920_add_share_token_to_inventories.rb
+++ b/db/migrate/20160420213920_add_share_token_to_inventories.rb
@@ -1,0 +1,5 @@
+class AddShareTokenToInventories < ActiveRecord::Migration
+  def change
+    add_column :inventories, :share_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -291,6 +291,7 @@ ActiveRecord::Schema.define(version: 20160427093012) do
     t.text     "message"
     t.datetime "assigned_at"
     t.integer  "total_participant_responses", default: 0, null: false
+    t.string   "share_token"
   end
 
   create_table "inventory_access_requests", force: :cascade do |t|
@@ -528,7 +529,7 @@ ActiveRecord::Schema.define(version: 20160427093012) do
   add_index "scores", ["response_id", "question_id"], name: "index_scores_on_response_id_and_question_id", unique: true, using: :btree
 
   create_table "sessions", force: :cascade do |t|
-    t.string   "session_id", null: false
+    t.string   "session_id", limit: 255, null: false
     t.text     "data"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -290,8 +290,8 @@ ActiveRecord::Schema.define(version: 20160427093012) do
     t.integer  "owner_id"
     t.text     "message"
     t.datetime "assigned_at"
-    t.integer  "total_participant_responses", default: 0, null: false
     t.string   "share_token"
+    t.integer  "total_participant_responses", default: 0, null: false
   end
 
   create_table "inventory_access_requests", force: :cascade do |t|

--- a/spec/controllers/v1/data_entries_controller_spec.rb
+++ b/spec/controllers/v1/data_entries_controller_spec.rb
@@ -55,7 +55,7 @@ describe V1::DataEntriesController do
       get :show, inventory_id: inventory.id, id: inventory.data_entries.first.id
       data_entry = assigns(:data_entry)
 
-      assert_response :success
+      expect(response).to have_http_status(:success)
       expect(data_entry.id).to eq(inventory.data_entries.first.id)
     end
   end
@@ -124,7 +124,7 @@ describe V1::DataEntriesController do
             data_capture: 'derp'
           }
 
-      assert_response 422
+      expect(response).to have_http_status(422)
       expect(json['errors'].values.flatten).to include("'derp' not permissible")
     end
 

--- a/spec/controllers/v1/inventories_controller_spec.rb
+++ b/spec/controllers/v1/inventories_controller_spec.rb
@@ -89,16 +89,35 @@ describe V1::InventoriesController do
   end
 
   describe 'GET #show' do
-    context 'when not authenticated' do
+    context 'anonymous user' do
+      context 'non existing inventory' do
+        before(:each) do
+          get :show, id: 1, format: :json
+        end
 
-      before(:each) do
-        get :show, id: 1, format: :json
+        it { expect(response).to have_http_status(:not_found) }
       end
 
-      it { expect(response).to have_http_status(:unauthorized) }
+      context 'existing inventory' do
+        let(:inventory) { FactoryGirl.create(:inventory) }
+
+        context 'by id' do
+          before(:each) do
+            get :show, id: inventory.id, format: :json
+          end
+          it { expect(response).to have_http_status(:unauthorized) }
+        end
+
+        context 'by share_token' do
+          before(:each) do
+            get :show, id: inventory.share_token, format: :json
+          end
+          it { expect(response).to have_http_status(:ok) }
+        end
+      end
     end
 
-    context 'when authenticated' do
+    context 'authenticated user' do
       context 'non existing inventory' do
         let(:user) { FactoryGirl.create(:user) }
 

--- a/spec/controllers/v1/product_entries_controller_spec.rb
+++ b/spec/controllers/v1/product_entries_controller_spec.rb
@@ -124,7 +124,7 @@ describe V1::ProductEntriesController do
             data_type: ['derp']
           }
 
-      assert_response 422
+      expect(response).to have_http_status(422)
       expect(json['errors'].values.flatten).to include('derp is not permissible')
     end
 

--- a/spec/models/inventory_spec.rb
+++ b/spec/models/inventory_spec.rb
@@ -122,13 +122,10 @@ describe Inventory do
     end
   end
 
-  describe '#analyis_count' do
+  describe '#current_analysis' do
     let(:inventory) { FactoryGirl.create(:inventory) }
-    let!(:other_analysis) { FactoryGirl.create_list(:analysis, 5) }
-    let!(:inventory_analysis) { FactoryGirl.create_list(:analysis, 6, inventory: inventory) }
+    let!(:last_analysis) { FactoryGirl.create_list(:analysis, 6, inventory: inventory).last }
 
-    it do
-      expect(inventory.analysis_count).to eq 6
-    end
+    it { expect(inventory.current_analysis).to eq last_analysis }
   end
 end

--- a/spec/models/inventory_spec.rb
+++ b/spec/models/inventory_spec.rb
@@ -66,6 +66,23 @@ describe Inventory do
     end
   end
 
+  describe '#share_token' do
+    let(:inventory) { FactoryGirl.create(:inventory) }
+    let!(:original_share_token) { inventory.share_token }
+    it do
+      expect(inventory.share_token).not_to be_empty
+    end
+
+    describe 'when saved again' do 
+      before do
+        inventory.save!
+      end
+      it do
+        expect(inventory.share_token).to eq original_share_token
+      end
+    end
+  end
+
   describe '#owner?' do
     context 'owner is current user' do
       let(:inventory) { FactoryGirl.create(:inventory) }

--- a/spec/models/inventory_spec.rb
+++ b/spec/models/inventory_spec.rb
@@ -121,4 +121,14 @@ describe Inventory do
       end
     end
   end
+
+  describe '#analyis_count' do
+    let(:inventory) { FactoryGirl.create(:inventory) }
+    let!(:other_analysis) { FactoryGirl.create_list(:analysis, 5) }
+    let!(:inventory_analysis) { FactoryGirl.create_list(:analysis, 6, inventory: inventory) }
+
+    it do
+      expect(inventory.analysis_count).to eq 6
+    end
+  end
 end


### PR DESCRIPTION
This PR is good to go:
* Ability to show report for inventory `#/inventories/:id/report`
* Ability to show shared inventory  `#/inventories/shared/:share_token/report` (You can get the share token with `Inventory.last.share_token`)
* `Go to Analysis` button behavior wired in as described [here](https://github.com/MobilityLabs/pdredesign-server/issues/184#issuecomment-214417075) under the assumption that future states/routes will be named `analysis_dashboard` and `analysis_assign`.
* `Go to Report` button wired for Dashboard's sidebar
* `Go to Dashboard` button wired for Report's sidebar
* inventory would be pre-selected in the `Create a New Analysis` dialog when triggered from the inventory report.