### PR TITLE
ensuring all analyses get a share token

### DIFF
--- a/db/migrate/20160601165704_resave_all_analyses_so_they_get_a_share_token.rb
+++ b/db/migrate/20160601165704_resave_all_analyses_so_they_get_a_share_token.rb
@@ -1,0 +1,5 @@
+class ResaveAllAnalysesSoTheyGetAShareToken < ActiveRecord::Migration
+  def change
+    Analysis.all.each{ |analysis| analysis.save }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160601103908) do
+ActiveRecord::Schema.define(version: 20160601165704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Because I forgot to do this on the `20160601103908_add_share_token_to_analyses.rb` migration.