### PR TITLE
Closes #344: Inventory participants creating analyses

### DIFF
--- a/app/assets/javascripts/client/inventories/InventoryDataEntriesCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryDataEntriesCtrl.js
@@ -142,8 +142,8 @@
     vm.isOwnerOrFacilitator = function () {
       var currentUser = SessionService.getCurrentUser();
 
-      return currentUser && (currentUser.id === vm.inventory.owner_id || vm.inventory.is_facilitator);
-    }
+      return currentUser && (currentUser.id === vm.inventory.owner_id || vm.inventory.is_facilitator_or_participant);
+    };
 
     $scope.$on('close-inventory-data-entry-modal', function() {
       vm.modalInstance && vm.modalInstance.dismiss('cancel');

--- a/app/assets/javascripts/client/inventories/InventoryProductEntriesCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryProductEntriesCtrl.js
@@ -144,8 +144,8 @@
     vm.isOwnerOrFacilitator = function () {
       var currentUser = SessionService.getCurrentUser();
 
-      return currentUser && (currentUser.id === vm.inventory.owner_id || vm.inventory.is_facilitator);
-    }
+      return currentUser && (currentUser.id === vm.inventory.owner_id || vm.inventory.is_facilitator_or_participant);
+    };
 
     $scope.$on('close-product-entry-modal', function() {
       vm.modalInstance && vm.modalInstance.dismiss('cancel');

--- a/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
+++ b/app/assets/javascripts/client/inventories/InventoryReportSidebarCtrl.js
@@ -16,8 +16,8 @@
 
     vm.inventory = inventory;
     vm.shared = $stateParams.shared || false;
-    vm.hideAnalysisAccess = vm.inventory.analysis_count === 0 && !vm.inventory.is_facilitator;
-    vm.creatingAnalysis = vm.inventory.analysis_count === 0 && vm.inventory.is_facilitator;
+    vm.hideAnalysisAccess = vm.inventory.analysis_count === 0 && !vm.inventory.is_facilitator_or_participant;
+    vm.creatingAnalysis = vm.inventory.analysis_count === 0 && vm.inventory.is_facilitator_or_participant;
     vm.shareURL = $state.href(
       'inventories_shared_report',
       {inventory_id: vm.inventory.share_token},

--- a/app/assets/javascripts/client/inventories/dashboard.html
+++ b/app/assets/javascripts/client/inventories/dashboard.html
@@ -24,7 +24,7 @@
         <participant user="user"></participant>
       </div>
     </div>
-    <div class="col-md-12 header" ng-if="inventoryDashboard.inventory.is_facilitator">
+    <div class="col-md-12 header" ng-if="inventoryDashboard.inventory.is_facilitator_or_participant">
       <div class="row">
         <div class="col-lg-12">
           <add-inventory-users-link send-invite="true"></add-inventory-users-link>

--- a/app/assets/javascripts/client/inventories/inventory_schedule.html
+++ b/app/assets/javascripts/client/inventories/inventory_schedule.html
@@ -21,7 +21,7 @@
   </div>
   <div class="inventory-schedule-buttons" ng-hide="inventorySchedule.onlySchedule">
     <button ui-sref="inventories_report({inventory_id: inventory.id})" class="btn btn-block btn-primary separator-margin">Go To Report</button>
-    <button class="btn btn-block btn-default separator-margin" ng-if="inventory.is_facilitator" ng-click="inventorySchedule.modifyDeadline()">Modify Schedule</button>
+    <button class="btn btn-block btn-default separator-margin" ng-if="inventory.is_facilitator_or_participant" ng-click="inventorySchedule.modifyDeadline()">Modify Schedule</button>
     <button ng-click="inventorySchedule.displayLearningQuestions()"
             class="btn btn-block btn-secondary separator-margin">Add/Review Learning Questions</button>
   </div>

--- a/app/authorizers/analysis_authorizer.rb
+++ b/app/authorizers/analysis_authorizer.rb
@@ -1,23 +1,34 @@
 class AnalysisAuthorizer < ApplicationAuthorizer
   def readable_by?(user)
-    is_owner_or_facilitator_of_inventory?(user)
+    fetch_inventory_permissions(user)
   end
 
   def creatable_by?(user)
-    is_owner_or_facilitator_of_inventory?(user)
+    fetch_inventory_permissions(user)
   end
 
   def updatable_by?(user)
-    is_owner_or_facilitator_of_inventory?(user)
+    fetch_inventory_permissions(user)
   end
 
   def deletable_by?(user)
-    is_owner_or_facilitator_of_inventory?(user)
+    fetch_inventory_permissions(user)
   end
 
   private
-  def is_owner_or_facilitator_of_inventory?(user)
-    resource.inventory.try(:owner?, user: user) ||
-        resource.inventory.try(:facilitator?, user: user)
+  def fetch_inventory_permissions(user)
+    is_owner_of_inventory?(user) || is_facilitator_of_inventory?(user) || is_participant_of_inventory?(user)
+  end
+
+  def is_facilitator_of_inventory?(user)
+    resource.inventory.try(:facilitator?, user: user)
+  end
+
+  def is_participant_of_inventory?(user)
+    resource.inventory.try(:participant?, user: user)
+  end
+
+  def is_owner_of_inventory?(user)
+    resource.inventory.try(:owner?, user: user)
   end
 end

--- a/app/views/v1/inventories/_inventory.json.jbuilder
+++ b/app/views/v1/inventories/_inventory.json.jbuilder
@@ -4,7 +4,7 @@ json.owner_id inventory.owner_id
 json.facilitator do
   json.partial! 'v1/shared/user', user: inventory.owner
 end
-json.is_facilitator inventory.facilitator?(user: current_user)
+json.is_facilitator inventory.facilitator?(user: current_user) || inventory.participant?(user: current_user)
 json.due_date inventory.deadline
 json.district_id inventory.district_id
 json.district_name inventory.district.name

--- a/app/views/v1/inventories/_inventory.json.jbuilder
+++ b/app/views/v1/inventories/_inventory.json.jbuilder
@@ -4,7 +4,7 @@ json.owner_id inventory.owner_id
 json.facilitator do
   json.partial! 'v1/shared/user', user: inventory.owner
 end
-json.is_facilitator inventory.facilitator?(user: current_user) || inventory.participant?(user: current_user)
+json.is_facilitator_or_participant inventory.facilitator?(user: current_user) || inventory.participant?(user: current_user)
 json.due_date inventory.deadline
 json.district_id inventory.district_id
 json.district_name inventory.district.name

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,14 +15,15 @@ ActiveRecord::Schema.define(version: 20160601165704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "access_requests", force: :cascade do |t|
     t.integer  "assessment_id"
     t.integer  "user_id"
-    t.string   "roles",                     default: [], array: true
+    t.string   "roles",         default: [], array: true
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "token",         limit: 255
+    t.string   "token"
   end
 
   create_table "analyses", force: :cascade do |t|
@@ -200,10 +201,10 @@ ActiveRecord::Schema.define(version: 20160601165704) do
   end
 
   create_table "district_messages", force: :cascade do |t|
-    t.string   "name",         limit: 255
-    t.string   "address",      limit: 255
-    t.string   "sender_name",  limit: 255
-    t.string   "sender_email", limit: 255
+    t.string   "name"
+    t.string   "address"
+    t.string   "sender_name"
+    t.string   "sender_email"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -248,14 +249,14 @@ ActiveRecord::Schema.define(version: 20160601165704) do
   end
 
   create_table "faq_categories", force: :cascade do |t|
-    t.string   "heading",    limit: 255
+    t.string   "heading"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "faq_questions", force: :cascade do |t|
-    t.string   "role",        limit: 255
-    t.string   "topic",       limit: 255
+    t.string   "role"
+    t.string   "topic"
     t.integer  "category_id"
     t.text     "content"
     t.text     "answer"
@@ -388,7 +389,6 @@ ActiveRecord::Schema.define(version: 20160601165704) do
 
   add_index "learning_questions", ["created_at"], name: "index_learning_questions_on_created_at", using: :btree
   add_index "learning_questions", ["tool_id"], name: "index_learning_questions_on_tool_id", using: :btree
-  add_index "learning_questions", ["tool_type", "tool_id"], name: "index_learning_questions_on_tool_type_and_tool_id", using: :btree
 
   create_table "messages", force: :cascade do |t|
     t.text     "content"
@@ -414,8 +414,8 @@ ActiveRecord::Schema.define(version: 20160601165704) do
   end
 
   create_table "organizations", force: :cascade do |t|
-    t.string "name", limit: 255
-    t.string "logo", limit: 255
+    t.string "name"
+    t.string "logo"
   end
 
   create_table "organizations_users", id: false, force: :cascade do |t|
@@ -596,27 +596,27 @@ ActiveRecord::Schema.define(version: 20160601165704) do
   add_index "technical_questions", ["product_entry_id"], name: "index_technical_questions_on_product_entry_id", using: :btree
 
   create_table "tool_categories", force: :cascade do |t|
-    t.string  "title",         limit: 255
+    t.string  "title"
     t.integer "display_order"
     t.integer "tool_phase_id"
   end
 
   create_table "tool_phases", force: :cascade do |t|
-    t.string  "title",         limit: 255
+    t.string  "title"
     t.text    "description"
     t.integer "display_order"
   end
 
   create_table "tool_subcategories", force: :cascade do |t|
-    t.string  "title",            limit: 255
+    t.string  "title"
     t.integer "display_order"
     t.integer "tool_category_id"
   end
 
   create_table "tools", force: :cascade do |t|
-    t.string  "title",               limit: 255
+    t.string  "title"
     t.text    "description"
-    t.string  "url",                 limit: 255
+    t.string  "url"
     t.boolean "is_default"
     t.integer "display_order"
     t.integer "tool_subcategory_id"
@@ -639,11 +639,11 @@ ActiveRecord::Schema.define(version: 20160601165704) do
   add_index "usage_questions", ["product_entry_id"], name: "index_usage_questions_on_product_entry_id", using: :btree
 
   create_table "user_invitations", force: :cascade do |t|
-    t.string  "first_name",    limit: 255
-    t.string  "last_name",     limit: 255
-    t.string  "email",         limit: 255
-    t.string  "team_role",     limit: 255
-    t.string  "token",         limit: 255
+    t.string  "first_name"
+    t.string  "last_name"
+    t.string  "email"
+    t.string  "team_role"
+    t.string  "token"
     t.integer "assessment_id"
     t.integer "user_id"
   end

--- a/spec/authorizers/analysis_authorizer_spec.rb
+++ b/spec/authorizers/analysis_authorizer_spec.rb
@@ -2,107 +2,124 @@ require 'spec_helper'
 
 describe AnalysisAuthorizer do
 
-  let(:subject) { AnalysisAuthorizer }
-  let(:member_user) { FactoryGirl.create(:user, :with_district) }
-  let(:participant_user) { FactoryGirl.create(:user, :with_district) }
-  let(:facilitator_user) { FactoryGirl.create(:user, :with_district) }
-  let(:other_user) { FactoryGirl.create(:user, :with_district) }
-  let(:inventory) { FactoryGirl.create(:inventory, :with_product_entries) }
+  subject { analysis }
 
-  before do
-    @analysis = FactoryGirl.create(:analysis, inventory: inventory)
-    FactoryGirl.create(:inventory_member, user: member_user, inventory: inventory)
-    FactoryGirl.create(:inventory_member, :as_participant, user: participant_user, inventory: inventory)
-    FactoryGirl.create(:inventory_member, :as_facilitator, user: facilitator_user, inventory: inventory)
-  end
+  let(:member_user) {
+    user = create(:user, :with_district)
+    create(:inventory_member, user: user, inventory: inventory)
+    user
+  }
 
-  context 'read' do
-    it "is readable by its inventory's owner" do
-      expect(@analysis).to be_readable_by(inventory.owner)
+  let(:participant_user) {
+    user = create(:user, :with_district)
+    create(:inventory_member, :as_participant, user: user, inventory: inventory)
+    user
+  }
+
+  let(:facilitator_user) {
+    user = create(:user, :with_district)
+    create(:inventory_member, :as_facilitator, user: user, inventory: inventory)
+    user
+  }
+
+  let(:other_user) {
+    create(:user, :with_district)
+  }
+
+  let(:inventory) {
+    create(:inventory, :with_product_entries)
+  }
+
+  let(:analysis) {
+    create(:analysis, inventory: inventory)
+  }
+
+  context 'when reading an analysis' do
+    context 'when the user is the inventory owner' do
+      it { is_expected.to be_readable_by(inventory.owner) }
     end
 
-    it "is not readable by its inventory's members" do
-      expect(@analysis).to_not be_readable_by(member_user)
+    context 'when the user is an inventory member' do
+      it { is_expected.to_not be_readable_by(member_user) }
     end
 
-    it "is not readable by its inventory's participants" do
-      expect(@analysis).to_not be_readable_by(participant_user)
+
+    context 'when the user is an inventory participant' do
+      it { is_expected.to be_readable_by(participant_user) }
     end
 
-    it "is readable by its inventory's facilitators" do
-      expect(@analysis).to be_readable_by(facilitator_user)
+    context 'when the user is an inventory facilitator' do
+      it { is_expected.to be_readable_by(facilitator_user) }
     end
 
-    it 'is not readable by randos' do
-      expect(@analysis).to_not be_readable_by(other_user)
-    end
-  end
-
-  context 'create' do
-    it "is creatable by its inventory's owner" do
-      expect(@analysis).to be_creatable_by(inventory.owner)
-    end
-
-    it "is not creatable by its inventory's members" do
-      expect(@analysis).to_not be_creatable_by(member_user)
-    end
-
-    it "is not creatable by its inventory's participants" do
-      expect(@analysis).to_not be_creatable_by(participant_user)
-    end
-
-    it "is creatable by its inventory's facilitators" do
-      expect(@analysis).to be_creatable_by(facilitator_user)
-    end
-
-    it 'is not creatable by randos' do
-      expect(@analysis).to_not be_creatable_by(other_user)
+    context 'when the user is not an inventory member, participant or facilitator' do
+      it { is_expected.to_not be_readable_by(other_user) }
     end
   end
 
-  context 'update' do
-    it "is updatable by its inventory's owner" do
-      expect(@analysis).to be_updatable_by(inventory.owner)
+  context 'when creating an analysis' do
+    context 'when the user is the inventory owner' do
+      it { is_expected.to be_creatable_by(inventory.owner) }
     end
 
-    it "is not updatable by its inventory's members" do
-      expect(@analysis).to_not be_updatable_by(member_user)
+    context 'when the user is an inventory member' do
+      it { is_expected.to_not be_creatable_by(member_user) }
     end
 
-    it "is not updatable by its inventory's participants" do
-      expect(@analysis).to_not be_updatable_by(participant_user)
+    context 'when the user is an inventory participant' do
+      it { is_expected.to be_creatable_by(participant_user) }
     end
 
-    it "is updatable by its inventory's facilitators" do
-      expect(@analysis).to be_updatable_by(facilitator_user)
+    context 'when the user is an inventory facilitator' do
+      it { is_expected.to be_creatable_by(facilitator_user) }
     end
 
-    it 'is not updatable by randos' do
-      expect(@analysis).to_not be_updatable_by(other_user)
+    context 'when the user is not an inventory member, participant or facilitator' do
+      it { is_expected.to_not be_creatable_by(other_user) }
     end
   end
 
-  context 'delete' do
-    it "is deletable by its inventory's owner" do
-      expect(@analysis).to be_deletable_by(inventory.owner)
+  context 'when updating an analysis' do
+    context 'when the user is the inventory owner' do
+      it { is_expected.to be_updatable_by(inventory.owner) }
     end
 
-    it "is not deletable by its inventory's members" do
-      expect(@analysis).to_not be_deletable_by(member_user)
+    context 'when the user is an inventory member' do
+      it { is_expected.to_not be_updatable_by(member_user) }
     end
 
-    it "is not deletable by its inventory's participants" do
-      expect(@analysis).to_not be_deletable_by(participant_user)
+    context 'when the user is an inventory participant' do
+      it { is_expected.to be_updatable_by(participant_user) }
     end
 
-    it "is deletable by its inventory's facilitators" do
-      expect(@analysis).to be_deletable_by(facilitator_user)
+    context 'when the user is an inventory facilitator' do
+      it { is_expected.to be_updatable_by(facilitator_user) }
     end
 
-    it 'is not deletable by randos' do
-      expect(@analysis).to_not be_deletable_by(other_user)
+    context 'when the user is not an inventory member, participant or facilitator' do
+      it { is_expected.to_not be_updatable_by(other_user) }
+    end
+  end
+
+  context 'when deleting an analysis' do
+    context 'when the user is the inventory owner' do
+      it { is_expected.to be_deletable_by(inventory.owner) }
+    end
+
+    context 'when the user is an inventory member' do
+      it { is_expected.to_not be_deletable_by(member_user) }
+    end
+
+    context 'when the user is an inventory participant' do
+      it { is_expected.to be_deletable_by(participant_user) }
+    end
+
+    context 'when the user is an inventory facilitator' do
+      it { is_expected.to be_deletable_by(facilitator_user) }
+    end
+
+    context 'when the user is not an inventory member, participant or facilitator' do
+      it { is_expected.to_not be_deletable_by(other_user) }
     end
   end
 end
-
-


### PR DESCRIPTION
This PR is good to go.  Notes:

 - Users which are listed as participants on an inventory may now create analyses from an inventory they're participating in, or from the top-level menu.

To verify:

 - Invite a user as a participant to an inventory.
 - Use that user to create an analysis as part of the inventory report page.
 - Use that user to create an analysis as part of the inventory listing page.

This will be deployed to staging and the ticket will be formally closed once verified.