### PR TITLE
Closes #307: Register analysis creator properly

### DIFF
--- a/app/controllers/v1/analysis_permissions_controller.rb
+++ b/app/controllers/v1/analysis_permissions_controller.rb
@@ -15,9 +15,12 @@ class V1::AnalysisPermissionsController < ApplicationController
 
   private
   def update_permission(permission)
-    user = User.find_by(email: permission["email"])
-    role = permission["role"]
-    role = "facilitator" if user.network_partner?
+    user = User.find_by(email: permission['email'])
+    if user.network_partner?
+      role = 'facilitator'
+    else
+      role = permission['role']
+    end
     permission = Analyses::Permission.new(analysis: analysis, user: user)
     permission.role = role
   end

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -89,8 +89,12 @@ class Analysis < ActiveRecord::Base
   def set_members_from_inventory
     %i|participants facilitators|.each do |member_type|
       self.inventory.send(member_type).each do |inventory_member|
-        self.send(member_type).create(user: inventory_member.user)
+        self.send(member_type).create(user: inventory_member.user) unless self.owner == inventory_member.user
       end
+    end
+
+    if self.inventory.owner != self.owner
+      self.facilitators.create(user: self.inventory.owner)
     end
   end
 

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -36,7 +36,7 @@ class Analysis < ActiveRecord::Base
   has_many :access_requests, class_name: 'AnalysisAccessRequest'
   has_one :response, as: :responder, dependent: :destroy
 
-  after_create :set_members_from_inventory
+  after_create :set_members_from_inventory, :add_facilitator_owner
   before_save :set_assigned_at, :ensure_share_token
 
   def facilitator?(user)
@@ -86,15 +86,15 @@ class Analysis < ActiveRecord::Base
   end
 
   private
+  def add_facilitator_owner
+    self.facilitators.create(user: owner) if owner
+  end
+
   def set_members_from_inventory
     %i|participants facilitators|.each do |member_type|
       self.inventory.send(member_type).each do |inventory_member|
         self.send(member_type).create(user: inventory_member.user) unless self.owner == inventory_member.user
       end
-    end
-
-    if self.inventory.owner != self.owner
-      self.facilitators.create(user: self.inventory.owner)
     end
   end
 

--- a/circle.yml
+++ b/circle.yml
@@ -4,5 +4,6 @@ machine:
 
 test:
   override:
+    - bundle exec rake db:migrate
     - bundle exec rspec
     - bundle exec rake jasmine:ci

--- a/db/migrate/20160712201921_ensure_analyses_assign_owner_to_facilitators.rb
+++ b/db/migrate/20160712201921_ensure_analyses_assign_owner_to_facilitators.rb
@@ -1,0 +1,10 @@
+class EnsureAnalysesAssignOwnerToFacilitators < ActiveRecord::Migration
+  def change
+    Analysis.reset_column_information
+    Analysis.all.each { |analysis|
+      unless analysis.facilitators.map(&:user).include?(analysis.owner)
+        analysis.facilitators.create(user: analysis.owner)
+      end
+    }
+  end
+end

--- a/spec/controllers/v1/analysis_permissions_controller_spec.rb
+++ b/spec/controllers/v1/analysis_permissions_controller_spec.rb
@@ -5,79 +5,106 @@ describe V1::AnalysisPermissionsController do
 
   describe '#show' do
     context 'logged-out user' do
-      let(:inventory) { FactoryGirl.create(:inventory, :with_analysis) }
-      let(:analysis) { inventory.analyses.first }
+      let(:inventory) {
+        create(:inventory, :with_analysis)
+      }
+
+      let(:analysis) {
+        inventory.analyses.first
+      }
+
       before(:each) do
         get :show,
-           inventory_id: inventory.id,
-           analysis_id: analysis.id,
-           format: :json
+            inventory_id: inventory.id,
+            analysis_id: analysis.id,
+            format: :json
       end
 
       it { expect(response).to have_http_status(:unauthorized) }
     end
 
     context 'logged-in user' do
-      let(:inventory) { FactoryGirl.create(:inventory, :with_analysis) }
-      let(:analysis) { inventory.analyses.first }
+      let(:inventory) {
+        create(:inventory, :with_analysis)
+      }
+
+      let(:analysis) {
+        inventory.analyses.first
+      }
 
       before(:each) do
-        FactoryGirl.create_list(:analysis_member, 2, :as_facilitator, analysis: analysis)
-        FactoryGirl.create_list(:analysis_member, 3, :as_participant, analysis: analysis)
+        create_list(:analysis_member, 2, :as_facilitator, analysis: analysis)
+        create_list(:analysis_member, 3, :as_participant, analysis: analysis)
         sign_in inventory.owner
         get :show,
-           inventory_id: inventory.id,
-           analysis_id: analysis.id,
-           format: :json
+            inventory_id: inventory.id,
+            analysis_id: analysis.id,
+            format: :json
       end
 
       it { expect(response).to have_http_status(:success) }
       it { expect(json).to have_at_least(5).items }
 
       it 'contain all facilitators' do
-        expect((json.select {|permission| permission['current_permission_level']['role'] == 'facilitator'}).map {|p| p['id']}).to have_at_least(2).items
+        expect((json.select { |permission| permission['current_permission_level']['role'] == 'facilitator' }).map { |p| p['id'] }).to have_at_least(2).items
       end
 
       it 'contain all participants' do
-        expect((json.select {|permission| permission['current_permission_level']['role'] == 'participant'}).map {|p| p['id']}).to have_at_least(3).items
+        expect((json.select { |permission| permission['current_permission_level']['role'] == 'participant' }).map { |p| p['id'] }).to have_at_least(3).items
       end
     end
   end
 
   describe '#update' do
     context 'logged-out user' do
-      let(:inventory) { FactoryGirl.create(:inventory, :with_analysis) }
-      let(:analysis) { inventory.analyses.first }
+      let(:inventory) {
+        create(:inventory, :with_analysis)
+      }
+
+      let(:analysis) {
+        inventory.analyses.first
+      }
+
       before(:each) do
         post :update,
-           inventory_id: inventory.id,
-           analysis_id: analysis.id,
-           format: :json
+             inventory_id: inventory.id,
+             analysis_id: analysis.id,
+             format: :json
       end
 
       it { expect(response).to have_http_status(:unauthorized) }
     end
 
     context 'logged-in user' do
-      let(:inventory) { FactoryGirl.create(:inventory, :with_analysis) }
-      let(:analysis) { inventory.analyses.first }
-      let(:original_participant_users) { analysis.participants.map(&:user) }
-      let(:original_participant_emails) { original_participant_users.map(&:email) }
+      let(:inventory) {
+        create(:inventory, :with_analysis)
+      }
+
+      let(:analysis) {
+        inventory.analyses.first
+      }
+
+      let(:original_participant_users) {
+        analysis.participants.map(&:user)
+      }
+
+      let(:original_participant_emails) {
+        original_participant_users.map(&:email)
+      }
 
       before(:each) do
-        FactoryGirl.create_list(:analysis_member, 2, :as_participant, analysis: analysis)
+        create_list(:analysis_member, 2, :as_participant, analysis: analysis)
         sign_in inventory.owner
         post :update,
-          inventory_id: inventory.id,
-          analysis_id: analysis.id,
-          format: :json,
-          permissions: original_participant_emails.map { |email| {email: email, role: 'facilitator'} }
+             inventory_id: inventory.id,
+             analysis_id: analysis.id,
+             format: :json,
+             permissions: original_participant_emails.map { |email| {email: email, role: 'facilitator'} }
       end
 
       it { expect(response).to have_http_status(:success) }
 
-      it 'changed all roles' do 
-        expect(analysis.facilitators.count).to be(inventory.members.count + 2)
+      it 'updated the specified user\'s roles' do
         expect(analysis.facilitators.map(&:user).map(&:email)).to include *original_participant_emails
       end
     end

--- a/spec/factories/inventories.rb
+++ b/spec/factories/inventories.rb
@@ -27,7 +27,7 @@ FactoryGirl.define do
       end
 
       after(:create) do |inventory, evaluator|
-        inventory.members << FactoryGirl.create_list(:inventory_member, evaluator.members)
+        inventory.members << create_list(:inventory_member, evaluator.members)
       end
     end
 
@@ -37,7 +37,7 @@ FactoryGirl.define do
       end
 
       after(:create) do |inventory, evaluator|
-        FactoryGirl.create_list(:inventory_member, evaluator.facilitators, :as_facilitator, inventory: inventory)
+        create_list(:inventory_member, evaluator.facilitators, :as_facilitator, inventory: inventory)
       end
     end
 
@@ -47,7 +47,7 @@ FactoryGirl.define do
       end
 
       after(:create) do |inventory, evaluator|
-        FactoryGirl.create_list(:inventory_member, evaluator.participants, :as_participant, inventory: inventory)
+        create_list(:inventory_member, evaluator.participants, :as_participant, inventory: inventory)
       end
     end
 
@@ -57,7 +57,7 @@ FactoryGirl.define do
       end
 
       after(:create) do |inventory, evaluator|
-        FactoryGirl.create_list(:product_entry, evaluator.product_entries, inventory: inventory)
+        create_list(:product_entry, evaluator.product_entries, inventory: inventory)
       end
     end
 
@@ -67,7 +67,7 @@ FactoryGirl.define do
       end
 
       after(:create) do |inventory, evaluator|
-        FactoryGirl.create_list(:data_entry, evaluator.data_entries, inventory: inventory)
+        create_list(:data_entry, evaluator.data_entries, inventory: inventory)
       end
     end
 
@@ -77,7 +77,7 @@ FactoryGirl.define do
       end
 
       after(:create) do |inventory, evaluator|
-        FactoryGirl.create_list(:analysis, evaluator.analysis, inventory: inventory)
+        create_list(:analysis, evaluator.analysis, inventory: inventory)
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -29,7 +29,7 @@ FactoryGirl.define do
   factory :user do
     email { Faker::Internet.safe_email }
     password { Faker::Internet.password(12) }
-    role  :district_member
+    role :district_member
     admin false
     first_name 'Example'
     last_name 'User'
@@ -44,8 +44,8 @@ FactoryGirl.define do
     after(:create) do |user, evaluator|
       if evaluator.district
         user.districts << evaluator.district
-      else 
-        user.districts = FactoryGirl.create_list(:district, evaluator.districts)
+      else
+        user.districts = create_list(:district, evaluator.districts)
       end
     end
   end

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -66,10 +66,87 @@ describe Analysis do
   end
 
   describe '#create' do
-    let(:inventory) { FactoryGirl.create(:inventory, :with_participants, :with_facilitators, participants: 2, facilitators: 2) }
-    subject { FactoryGirl.create(:analysis, inventory: inventory ) }
 
-    it { expect(subject.members.count).to be inventory.members.count }
-    it { expect(subject.members.pluck(:role)).to match_array inventory.members.pluck(:role) }
+    context 'when user creating new analysis is the owner of its parent inventory' do
+
+      let(:owner) {
+        create(:user)
+      }
+
+      let(:inventory) {
+        create(:inventory, :with_participants, :with_facilitators, participants: 2, facilitators: 2, owner: owner)
+      }
+
+      subject {
+        create(:analysis, inventory: inventory, owner: owner)
+      }
+
+      it {
+        expect(subject.owner).to equal owner
+      }
+
+      it 'does not register the owner as a particpant' do
+        expect(subject.participants.map(&:user).include?(owner)).to be false
+      end
+
+      it 'does not register the owner as a facilitator' do
+        expect(subject.facilitators.map(&:user).include?(owner)).to be false
+      end
+    end
+
+    context 'when user creating new analysis is a facilitator of its parent inventory' do
+
+      let(:owner) {
+        inventory.facilitators.sample.user
+      }
+
+      let(:inventory) {
+        create(:inventory, :with_participants, :with_facilitators, participants: 2, facilitators: 2)
+      }
+
+      subject {
+        create(:analysis, inventory: inventory, owner: owner)
+      }
+
+
+      it {
+        expect(subject.owner).to equal owner
+      }
+
+      it 'does not copy the user across as a facilitator' do
+        expect(subject.facilitators.map(&:user).include?(owner)).to be false
+      end
+
+      it 'adds the owner of the original inventory as a facilitator' do
+        expect(subject.facilitators.map(&:user).include?(inventory.owner)).to be true
+      end
+    end
+
+    context 'when user creating new analysis is a participant of its parent inventory' do
+
+      let(:owner) {
+        inventory.participants.sample.user
+      }
+
+      let(:inventory) {
+        create(:inventory, :with_participants, :with_facilitators, participants: 2, facilitators: 2)
+      }
+
+      subject {
+        create(:analysis, inventory: inventory, owner: owner)
+      }
+
+      it {
+        expect(subject.owner).to equal owner
+      }
+
+      it 'does not copy the user across as a participant' do
+        expect(subject.participants.map(&:user).include?(owner)).to be false
+      end
+
+      it 'adds the owner of the original inventory as a facilitator' do
+        expect(subject.facilitators.map(&:user).include?(inventory.owner)).to be true
+      end
+    end
   end
 end

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -49,7 +49,7 @@ describe Analysis do
       it 'requires :due_date when assigned_at is present' do
         expect(@analysis.valid?).to eq(false)
         expect(@analysis.errors[:message])
-          .to include("can\'t be blank")
+          .to include("can't be blank")
 
         @analysis.assigned_at = nil
         @analysis.valid?
@@ -89,8 +89,8 @@ describe Analysis do
         expect(subject.participants.map(&:user).include?(owner)).to be false
       end
 
-      it 'does not register the owner as a facilitator' do
-        expect(subject.facilitators.map(&:user).include?(owner)).to be false
+      it 'registers the owner as a facilitator' do
+        expect(subject.facilitators.map(&:user).include?(owner)).to be true
       end
     end
 
@@ -108,13 +108,12 @@ describe Analysis do
         create(:analysis, inventory: inventory, owner: owner)
       }
 
-
       it {
         expect(subject.owner).to equal owner
       }
 
-      it 'does not copy the user across as a facilitator' do
-        expect(subject.facilitators.map(&:user).include?(owner)).to be false
+      it 'copies the user across as a facilitator' do
+        expect(subject.facilitators.map(&:user).include?(owner)).to be true
       end
 
       it 'adds the owner of the original inventory as a facilitator' do


### PR DESCRIPTION
This PR is good to go.  Notes:
 
 - We permit the creation of analyses from users that aren't originally facilitators on the inventory; they are treated then as the owner and moved into the group of facilitators on the analysis.
 - There is a migration to ensure any existing analyses' owners are also registered as facilitators should there be any lingering discrepancies.