### PR TITLE
Closes #302:  Remove link style from entry lists

### DIFF
--- a/app/assets/javascripts/client/common_list/entry_view.html
+++ b/app/assets/javascripts/client/common_list/entry_view.html
@@ -4,9 +4,7 @@
   <analysis-entity-status entity="entity" ng-if="context === 'analysis'"></analysis-entity-status>
   <div class="entry-content">
     <div class="entry-details">
-      <div class="disable-entry details"
-           ng-class="entry.activeAssessmentLink(entity)"
-           ng-click="entry.gotoLocation(entry.responseLink(entity))">
+      <div class="disable-entry details" ng-class="entry.activeAssessmentLink(entity)">
         <h3 class='name'>{{entity.name}}
           <i ng-hide="entity.has_access" class="fa fa-lock"></i>
         </h3>

--- a/app/assets/stylesheets/common_list/entry.sass
+++ b/app/assets/stylesheets/common_list/entry.sass
@@ -32,21 +32,17 @@
       background-color: $background-color-body
       height: 82px
       padding: 10px
-      &:hover
-        cursor: pointer
-        h3
-          color: darken($primary-color, 20%)
-          text-decoration: underline
-          cursor: pointer
       .details
         display: inline-block
-      .links
-        top: 0
-        display: inline-block
-        vertical-align: top
-        float: right
-        font-size: 12px
-        font-weight: 600
+    .links
+      top: 0
+      display: inline-block
+      vertical-align: top
+      float: right
+      font-size: 12px
+      font-weight: 600
+      text-decoration: underline
+      cursor: pointer
     .entry-footer
       padding: 10px
       border: 1px solid $background-color-body


### PR DESCRIPTION
This PR is good to go.  Notes:

 - This removes the link from the listing of assessments, inventories and analyses, such that when one hovers over the title, no underlined text nor cursor (for clicking a link) appear.