### PR TITLE
Closes #401: unified tool members table

### DIFF
--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -8,7 +8,7 @@
 #  roles         :string           default([]), is an Array
 #  created_at    :datetime
 #  updated_at    :datetime
-#  token         :string
+#  token         :string(255)
 #
 
 class AccessRequest < ActiveRecord::Base

--- a/app/models/district_message.rb
+++ b/app/models/district_message.rb
@@ -3,10 +3,10 @@
 # Table name: district_messages
 #
 #  id           :integer          not null, primary key
-#  name         :string
-#  address      :string
-#  sender_name  :string
-#  sender_email :string
+#  name         :string(255)
+#  address      :string(255)
+#  sender_name  :string(255)
+#  sender_email :string(255)
 #  created_at   :datetime
 #  updated_at   :datetime
 #

--- a/app/models/faq/category.rb
+++ b/app/models/faq/category.rb
@@ -3,7 +3,7 @@
 # Table name: faq_categories
 #
 #  id         :integer          not null, primary key
-#  heading    :string
+#  heading    :string(255)
 #  created_at :datetime
 #  updated_at :datetime
 #

--- a/app/models/faq/question.rb
+++ b/app/models/faq/question.rb
@@ -3,8 +3,8 @@
 # Table name: faq_questions
 #
 #  id          :integer          not null, primary key
-#  role        :string
-#  topic       :string
+#  role        :string(255)
+#  topic       :string(255)
 #  category_id :integer
 #  content     :text
 #  answer      :text

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -3,8 +3,8 @@
 # Table name: organizations
 #
 #  id   :integer          not null, primary key
-#  name :string
-#  logo :string
+#  name :string(255)
+#  logo :string(255)
 #
 
 class Organization < ActiveRecord::Base

--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -3,9 +3,9 @@
 # Table name: tools
 #
 #  id                  :integer          not null, primary key
-#  title               :string
+#  title               :string(255)
 #  description         :text
-#  url                 :string
+#  url                 :string(255)
 #  is_default          :boolean
 #  display_order       :integer
 #  tool_subcategory_id :integer

--- a/app/models/tool_category.rb
+++ b/app/models/tool_category.rb
@@ -3,7 +3,7 @@
 # Table name: tool_categories
 #
 #  id            :integer          not null, primary key
-#  title         :string
+#  title         :string(255)
 #  display_order :integer
 #  tool_phase_id :integer
 #

--- a/app/models/tool_member.rb
+++ b/app/models/tool_member.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: tool_members
+#
+#  tool_type   :string
+#  tool_id     :integer
+#  role        :integer
+#  user_id     :integer          not null
+#  invited_at  :datetime
+#  reminded_at :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+class ToolMember < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :tool, polymorphic: true
+
+  enum member_role: {
+      facilitator: 0,
+      participant: 1
+  }
+
+  validates_inclusion_of :role, in: ToolMember.member_roles.values
+  validates_uniqueness_of :role, scope: [:user_id, :tool_id, :tool_type]
+end

--- a/app/models/tool_phase.rb
+++ b/app/models/tool_phase.rb
@@ -3,7 +3,7 @@
 # Table name: tool_phases
 #
 #  id            :integer          not null, primary key
-#  title         :string
+#  title         :string(255)
 #  description   :text
 #  display_order :integer
 #

--- a/app/models/tool_subcategory.rb
+++ b/app/models/tool_subcategory.rb
@@ -3,7 +3,7 @@
 # Table name: tool_subcategories
 #
 #  id               :integer          not null, primary key
-#  title            :string
+#  title            :string(255)
 #  display_order    :integer
 #  tool_category_id :integer
 #

--- a/app/models/user_invitation.rb
+++ b/app/models/user_invitation.rb
@@ -3,11 +3,11 @@
 # Table name: user_invitations
 #
 #  id            :integer          not null, primary key
-#  first_name    :string
-#  last_name     :string
-#  email         :string
-#  team_role     :string
-#  token         :string
+#  first_name    :string(255)
+#  last_name     :string(255)
+#  email         :string(255)
+#  team_role     :string(255)
+#  token         :string(255)
 #  assessment_id :integer
 #  user_id       :integer
 #

--- a/db/migrate/20160919151705_create_tool_members.rb
+++ b/db/migrate/20160919151705_create_tool_members.rb
@@ -1,0 +1,17 @@
+class CreateToolMembers < ActiveRecord::Migration
+  def change
+    create_table :tool_members, id: false do |t|
+      t.string :tool_type
+      t.integer :tool_id
+      t.integer :role
+      t.references :user, null: false
+      t.timestamp :invited_at
+      t.timestamp :reminded_at
+      t.timestamps null: false
+    end
+
+    add_index :tool_members, [:user_id, :role, :tool_id, :tool_type],
+              unique: true,
+              name: 'idx_tool_members_unique'
+  end
+end

--- a/db/migrate/20160919195632_initial_tool_members_data_migration.rb
+++ b/db/migrate/20160919195632_initial_tool_members_data_migration.rb
@@ -1,0 +1,52 @@
+class InitialToolMembersDataMigration < ActiveRecord::Migration
+  def change
+    # Migrate over Analyses
+    AnalysisMember.all.each do |analysis_member|
+      ToolMember.create!(tool: analysis_member.analysis,
+                        role: ToolMember.member_roles[analysis_member.role.downcase.to_sym],
+                        user: analysis_member.user,
+                        invited_at: analysis_member.invited_at,
+                        reminded_at: analysis_member.reminded_at,
+                        created_at: analysis_member.created_at,
+                        updated_at: Time.now)
+    end
+
+    # Migrate over Inventories
+    InventoryMember.all.each do |inventory_member|
+      ToolMember.create!(tool: inventory_member.inventory,
+                         role: ToolMember.member_roles[inventory_member.role.downcase.to_sym],
+                         user: inventory_member.user,
+                         invited_at: inventory_member.invited_at,
+                         reminded_at: inventory_member.reminded_at,
+                         created_at: inventory_member.created_at,
+                         updated_at: Time.now)
+    end
+
+    Assessment.all.each do |assessment|
+      # Migrate over Assessment Facilitators
+      assessment.facilitators.each do |facilitator|
+        ToolMember.create!(tool: assessment,
+                           role: ToolMember.member_roles[:facilitator],
+                           user: facilitator,
+                           # No context exists as to when a facilitator is invited in an assessment.
+                           # We will assume that the time was when the assessment was created.
+                           invited_at: assessment.created_at,
+                           # No context exists as to when a facilitator is ever reminded of anything.
+                           # We will assume nil for this instance.
+                           reminded_at: nil,
+                           created_at: assessment.created_at,
+                           updated_at: Time.now)
+      end
+
+      assessment.participants.each do |participant|
+        ToolMember.create!(tool: assessment,
+                           role: ToolMember.member_roles[:participant],
+                           user: participant.user,
+                           invited_at: participant.created_at,
+                           reminded_at: participant.reminded_at,
+                           created_at: participant.created_at,
+                           updated_at: Time.now)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160831174134) do
+ActiveRecord::Schema.define(version: 20160919151705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -596,6 +596,19 @@ ActiveRecord::Schema.define(version: 20160831174134) do
     t.integer "display_order"
     t.integer "tool_phase_id"
   end
+
+  create_table "tool_members", id: false, force: :cascade do |t|
+    t.string   "tool_type"
+    t.integer  "tool_id"
+    t.integer  "role"
+    t.integer  "user_id",     null: false
+    t.datetime "invited_at"
+    t.datetime "reminded_at"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "tool_members", ["user_id", "role", "tool_id", "tool_type"], name: "idx_tool_members_unique", unique: true, using: :btree
 
   create_table "tool_phases", force: :cascade do |t|
     t.string  "title"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160919151705) do
+ActiveRecord::Schema.define(version: 20160919195632) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,10 +19,10 @@ ActiveRecord::Schema.define(version: 20160919151705) do
   create_table "access_requests", force: :cascade do |t|
     t.integer  "assessment_id"
     t.integer  "user_id"
-    t.string   "roles",         default: [], array: true
+    t.string   "roles",                     default: [], array: true
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "token"
+    t.string   "token",         limit: 255
   end
 
   create_table "analyses", force: :cascade do |t|
@@ -198,10 +198,10 @@ ActiveRecord::Schema.define(version: 20160919151705) do
   end
 
   create_table "district_messages", force: :cascade do |t|
-    t.string   "name"
-    t.string   "address"
-    t.string   "sender_name"
-    t.string   "sender_email"
+    t.string   "name",         limit: 255
+    t.string   "address",      limit: 255
+    t.string   "sender_name",  limit: 255
+    t.string   "sender_email", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -246,14 +246,14 @@ ActiveRecord::Schema.define(version: 20160919151705) do
   end
 
   create_table "faq_categories", force: :cascade do |t|
-    t.string   "heading"
+    t.string   "heading",    limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "faq_questions", force: :cascade do |t|
-    t.string   "role"
-    t.string   "topic"
+    t.string   "role",        limit: 255
+    t.string   "topic",       limit: 255
     t.integer  "category_id"
     t.text     "content"
     t.text     "answer"
@@ -410,8 +410,8 @@ ActiveRecord::Schema.define(version: 20160919151705) do
   end
 
   create_table "organizations", force: :cascade do |t|
-    t.string "name"
-    t.string "logo"
+    t.string "name", limit: 255
+    t.string "logo", limit: 255
   end
 
   create_table "organizations_users", id: false, force: :cascade do |t|
@@ -592,7 +592,7 @@ ActiveRecord::Schema.define(version: 20160919151705) do
   add_index "technical_questions", ["product_entry_id"], name: "index_technical_questions_on_product_entry_id", using: :btree
 
   create_table "tool_categories", force: :cascade do |t|
-    t.string  "title"
+    t.string  "title",         limit: 255
     t.integer "display_order"
     t.integer "tool_phase_id"
   end
@@ -611,21 +611,21 @@ ActiveRecord::Schema.define(version: 20160919151705) do
   add_index "tool_members", ["user_id", "role", "tool_id", "tool_type"], name: "idx_tool_members_unique", unique: true, using: :btree
 
   create_table "tool_phases", force: :cascade do |t|
-    t.string  "title"
+    t.string  "title",         limit: 255
     t.text    "description"
     t.integer "display_order"
   end
 
   create_table "tool_subcategories", force: :cascade do |t|
-    t.string  "title"
+    t.string  "title",            limit: 255
     t.integer "display_order"
     t.integer "tool_category_id"
   end
 
   create_table "tools", force: :cascade do |t|
-    t.string  "title"
+    t.string  "title",               limit: 255
     t.text    "description"
-    t.string  "url"
+    t.string  "url",                 limit: 255
     t.boolean "is_default"
     t.integer "display_order"
     t.integer "tool_subcategory_id"
@@ -648,11 +648,11 @@ ActiveRecord::Schema.define(version: 20160919151705) do
   add_index "usage_questions", ["product_entry_id"], name: "index_usage_questions_on_product_entry_id", using: :btree
 
   create_table "user_invitations", force: :cascade do |t|
-    t.string  "first_name"
-    t.string  "last_name"
-    t.string  "email"
-    t.string  "team_role"
-    t.string  "token"
+    t.string  "first_name",    limit: 255
+    t.string  "last_name",     limit: 255
+    t.string  "email",         limit: 255
+    t.string  "team_role",     limit: 255
+    t.string  "token",         limit: 255
     t.integer "assessment_id"
     t.integer "user_id"
   end

--- a/spec/factories/access_requests.rb
+++ b/spec/factories/access_requests.rb
@@ -8,7 +8,7 @@
 #  roles         :string           default([]), is an Array
 #  created_at    :datetime
 #  updated_at    :datetime
-#  token         :string
+#  token         :string(255)
 #
 
 require 'securerandom'

--- a/spec/factories/tool_members.rb
+++ b/spec/factories/tool_members.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: tool_members
+#
+#  tool_type   :string
+#  tool_id     :integer
+#  role        :integer
+#  user_id     :integer          not null
+#  invited_at  :datetime
+#  reminded_at :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+FactoryGirl.define do
+  factory :tool_member do
+    association :user
+
+    trait :as_analysis_member do
+      association :tool, factory: :analysis
+    end
+
+    trait :as_inventory_member do
+      association :tool, factory: :inventory
+    end
+
+    trait :as_facilitator do
+      role ToolMember.member_roles[:facilitator]
+    end
+
+    trait :as_participant do
+      role ToolMember.member_roles[:participant]
+    end
+  end
+end

--- a/spec/factories/user_invitations.rb
+++ b/spec/factories/user_invitations.rb
@@ -3,11 +3,11 @@
 # Table name: user_invitations
 #
 #  id            :integer          not null, primary key
-#  first_name    :string
-#  last_name     :string
-#  email         :string
-#  team_role     :string
-#  token         :string
+#  first_name    :string(255)
+#  last_name     :string(255)
+#  email         :string(255)
+#  team_role     :string(255)
+#  token         :string(255)
 #  assessment_id :integer
 #  user_id       :integer
 #

--- a/spec/models/access_request_spec.rb
+++ b/spec/models/access_request_spec.rb
@@ -8,7 +8,7 @@
 #  roles         :string           default([]), is an Array
 #  created_at    :datetime
 #  updated_at    :datetime
-#  token         :string
+#  token         :string(255)
 #
 
 require 'spec_helper'

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -13,9 +13,8 @@
 #  district_id     :integer
 #  message         :text
 #  assigned_at     :datetime
-#  mandrill_id     :string(255)
-#  mandrill_html   :text
 #  report_takeaway :text
+#  share_token     :string
 #
 
 require 'spec_helper'

--- a/spec/models/district_message_spec.rb
+++ b/spec/models/district_message_spec.rb
@@ -3,10 +3,10 @@
 # Table name: district_messages
 #
 #  id           :integer          not null, primary key
-#  name         :string
-#  address      :string
-#  sender_name  :string
-#  sender_email :string
+#  name         :string(255)
+#  address      :string(255)
+#  sender_name  :string(255)
+#  sender_email :string(255)
 #  created_at   :datetime
 #  updated_at   :datetime
 #

--- a/spec/models/faq/question_spec.rb
+++ b/spec/models/faq/question_spec.rb
@@ -3,8 +3,8 @@
 # Table name: faq_questions
 #
 #  id          :integer          not null, primary key
-#  role        :string
-#  topic       :string
+#  role        :string(255)
+#  topic       :string(255)
 #  category_id :integer
 #  content     :text
 #  answer      :text

--- a/spec/models/tool_category_spec.rb
+++ b/spec/models/tool_category_spec.rb
@@ -3,7 +3,7 @@
 # Table name: tool_categories
 #
 #  id            :integer          not null, primary key
-#  title         :string
+#  title         :string(255)
 #  display_order :integer
 #  tool_phase_id :integer
 #

--- a/spec/models/tool_member_spec.rb
+++ b/spec/models/tool_member_spec.rb
@@ -1,0 +1,100 @@
+# == Schema Information
+#
+# Table name: tool_members
+#
+#  tool_type   :string
+#  tool_id     :integer
+#  role        :integer
+#  user_id     :integer          not null
+#  invited_at  :datetime
+#  reminded_at :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+require 'spec_helper'
+
+describe ToolMember do
+  it {
+    is_expected.to belong_to :user
+  }
+
+  it {
+    is_expected.to belong_to :tool
+  }
+
+  it {
+    is_expected.to validate_inclusion_of(:role).in_array(ToolMember.member_roles.values)
+  }
+
+  context 'when a user is a member of a tool' do
+    context 'when the user is a facilitator' do
+      let(:user) {
+        create(:user)
+      }
+
+      let(:tool_member) {
+        create(:tool_member, :as_inventory_member, :as_facilitator, user: user)
+      }
+
+      let(:new_tool_member) {
+        build(:tool_member, :as_inventory_member, :as_participant, user: user)
+      }
+
+      it 'allows the user to be added as a participant' do
+        expect{new_tool_member.save!}.to_not raise_error
+      end
+    end
+
+    context 'when the user is a facilitator' do
+      let(:user) {
+        create(:user)
+      }
+
+      let(:tool_member) {
+        create(:tool_member, :as_inventory_member, :as_facilitator, user: user)
+      }
+
+      let(:new_tool_member) {
+        build(:tool_member, :as_inventory_member, :as_participant, user: user)
+      }
+
+      it 'allows the user to be added as a participant' do
+        expect{new_tool_member.save!}.to_not raise_error
+      end
+    end
+
+    context 'when the user is both a facilitator and participant' do
+      let(:user) {
+        create(:user)
+      }
+
+      let(:inventory) {
+        create(:inventory)
+      }
+
+      let!(:membership) {
+        create(:tool_member, :as_facilitator, user: user, tool: inventory)
+        create(:tool_member, :as_participant, user: user, tool: inventory)
+      }
+
+      let(:new_participant_tool_member) {
+        build(:tool_member, :as_participant, user: user, tool: inventory)
+      }
+
+      let(:new_facilitator_participant_member) {
+        build(:tool_member, :as_facilitator, user: user, tool: inventory)
+      }
+
+      it 'does not allow the user to become a participant again' do
+        expect{new_participant_tool_member.save!}
+            .to raise_error(ActiveRecord::RecordInvalid, /Role has already been taken/)
+      end
+
+      it 'does not allow the user to become a facilitator again' do
+        expect{new_facilitator_participant_member.save!}
+            .to raise_error(ActiveRecord::RecordInvalid, /Role has already been taken/)
+      end
+    end
+  end
+end

--- a/spec/models/tool_phase_spec.rb
+++ b/spec/models/tool_phase_spec.rb
@@ -3,7 +3,7 @@
 # Table name: tool_phases
 #
 #  id            :integer          not null, primary key
-#  title         :string
+#  title         :string(255)
 #  description   :text
 #  display_order :integer
 #

--- a/spec/models/user_invitation_spec.rb
+++ b/spec/models/user_invitation_spec.rb
@@ -3,11 +3,11 @@
 # Table name: user_invitations
 #
 #  id            :integer          not null, primary key
-#  first_name    :string
-#  last_name     :string
-#  email         :string
-#  team_role     :string
-#  token         :string
+#  first_name    :string(255)
+#  last_name     :string(255)
+#  email         :string(255)
+#  team_role     :string(255)
+#  token         :string(255)
 #  assessment_id :integer
 #  user_id       :integer
 #


### PR DESCRIPTION
This PR is good to go and is eligible to be merged directly into staging.  Notes:

 - This PR adds the new `ToolMember` model and allows us to encapsulate all member-specific relationships in one place.
 - This is a pure backend change, so there are no public-facing changes to verify.