### PR TITLE
Closes #411 Add owner on tool creation

### DIFF
--- a/app/controllers/v1/analyses_controller.rb
+++ b/app/controllers/v1/analyses_controller.rb
@@ -26,6 +26,7 @@ class V1::AnalysesController < ApplicationController
     @analysis.owner = current_user
 
     if @analysis.save
+      ToolMember.create!(user: @analysis.owner, tool: @analysis, role: ToolMember.member_roles[:facilitator])
       render template: 'v1/analyses/show', status: 201
     else
       render_error

--- a/app/controllers/v1/assessments_controller.rb
+++ b/app/controllers/v1/assessments_controller.rb
@@ -44,6 +44,7 @@ class V1::AssessmentsController < ApplicationController
     assign_current_user_as_participant(@assessment) if current_user.district_member?
 
     if @assessment.save
+      ToolMember.create!(user: @assessment.user, tool: @assessment, role: ToolMember.member_roles[:facilitator])
       render :show
     else
       @errors = @assessment.errors

--- a/app/controllers/v1/inventories_controller.rb
+++ b/app/controllers/v1/inventories_controller.rb
@@ -18,6 +18,7 @@ class V1::InventoriesController < ApplicationController
     @inventory.district = District.where(id: inventory_params[:district][:id]).first
     @inventory.owner = current_user
     if @inventory.save
+      ToolMember.create!(user: @inventory.owner, tool: @inventory, role: ToolMember.member_roles[:facilitator])
       render template: 'v1/inventories/show'
     else
       render_error

--- a/spec/controllers/v1/analyses_controller_spec.rb
+++ b/spec/controllers/v1/analyses_controller_spec.rb
@@ -51,6 +51,10 @@ describe V1::AnalysesController do
       expect(json['id']).not_to be_nil
       expect(Analysis.where(id:json['id']).first).not_to be_nil
       expect(Analysis.where(id:json['id']).first.owner).to eq inventory.owner
+      expect(ToolMember.find_by(tool: assigns(:analysis),
+                                user: inventory.owner,
+                                role: ToolMember.member_roles[:facilitator]
+      )).to_not be_nil
     end
   end
 

--- a/spec/controllers/v1/assessments_controller_spec.rb
+++ b/spec/controllers/v1/assessments_controller_spec.rb
@@ -448,6 +448,12 @@ describe V1::AssessmentsController do
           assessment = Assessment.find(json['id'])
           expect(assessment.participant?(facilitator)).to be true
         }
+
+        it {
+          expect(ToolMember.find_by(tool: assigns(:assessment),
+                                    user: facilitator,
+                                    role: ToolMember.member_roles[:facilitator])).to_not be_nil
+        }
       end
 
       context 'when user is a district member' do

--- a/spec/controllers/v1/inventories_controller_spec.rb
+++ b/spec/controllers/v1/inventories_controller_spec.rb
@@ -257,6 +257,13 @@ describe V1::InventoriesController do
         it { expect(json['updated_at']).to_not be_nil }
         it { expect(json['district_name']).to_not be_nil }
 
+        it {
+          expect(ToolMember.find_by(tool: assigns(:inventory),
+                                    user: user,
+                                    role: ToolMember.member_roles[:facilitator])).to_not be_nil
+        }
+
+
         it 'persists the entity' do
           expect(Inventory.all.size).to eq 1
         end

--- a/spec/controllers/v1/tool_members_controller_spec.rb
+++ b/spec/controllers/v1/tool_members_controller_spec.rb
@@ -490,6 +490,10 @@ describe V1::ToolMembersController do
             create(:tool_member, :as_facilitator, tool: tool, user: user)
           }
 
+          let(:roles) {
+            MembershipHelper.humanize_roles(ToolMember.where(tool: tool, user: user).select(:role).map(&:role))
+          }
+
           before(:each) do
             sign_in user
             post :request_access, tool_type: tool.class.to_s, tool_id: tool.id, access_request: {roles: [0, 1]}
@@ -500,7 +504,7 @@ describe V1::ToolMembersController do
           }
 
           it {
-            expect(json['errors']['base'][0]).to eq "Access for #{user.email} for #{tool.name} already exists at these levels: facilitator, participant"
+            expect(json['errors']['base'][0]).to eq "Access for #{user.email} for #{tool.name} already exists at these levels: #{roles.join(', ')}"
           }
         end
       end


### PR DESCRIPTION
This PR is ready to go and is eligible for to be merged directly onto staging.  Notes:

 - After each tool is created (assessment, inventory, analysis), we also (forcefully) create a new ToolMember with the owner of the tool as a facilitator.