### PR TITLE
Closes #392: Fix assessment error message

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -73,7 +73,7 @@ class Assessment < ActiveRecord::Base
 
   def validate_participants
     return unless self.participants.empty?
-    errors.add :participant_ids, 'You must assign participants to this assessment.'
+    errors.add :participants, 'must be assigned to this assessment'
   end
 
   def meeting_date_not_in_the_past

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -184,7 +184,7 @@ describe Assessment do
       }
 
       it {
-        expect(assessment.errors[:participant_ids]).to include 'You must assign participants to this assessment.'
+        expect(assessment.errors[:participants]).to include 'must be assigned to this assessment'
       }
     end
 


### PR DESCRIPTION
This PR is good to go and is eligible for immediate deployment for staging.  Notes:

 - This message only applies for setting a consensus date.  The message will appear to be more fluid than before.